### PR TITLE
15 datasets cataloged. Please see the details in the comment section.

### DIFF
--- a/intake-catalogs/ua_200_ECCC-GEM_anoms.daily.e2.yaml
+++ b/intake-catalogs/ua_200_ECCC-GEM_anoms.daily.e2.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/anoms/ECCC-GEM/ua_200_ECCC-GEM_*.anoms.daily.e2.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_200_EMC-GEFS_anoms.daily.e10.yaml
+++ b/intake-catalogs/ua_200_EMC-GEFS_anoms.daily.e10.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/anoms/EMC-GEFS/ua_200_EMC-GEFS_*.anoms.daily.e10.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_200_ESRL-FIMr1p1_anoms.daily.e2.yaml
+++ b/intake-catalogs/ua_200_ESRL-FIMr1p1_anoms.daily.e2.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/anoms/ESRL-FIMr1p1/ua_200_ESRL-FIMr1p1_*.anoms.daily.e2.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_200_GMAO-GEOS_V2p1_anoms.daily.e3.yaml
+++ b/intake-catalogs/ua_200_GMAO-GEOS_V2p1_anoms.daily.e3.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/anoms/GMAO-GEOS_V2p1/ua_200_GMAO-GEOS_V2p1_*.anoms.daily.e3.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_200_RSMAS-CCSM4_anoms.daily.e2.yaml
+++ b/intake-catalogs/ua_200_RSMAS-CCSM4_anoms.daily.e2.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/anoms/RSMAS-CCSM4/ua_200_RSMAS-CCSM4_*.anoms.daily.e2.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_ECCC-GEM_climo.p.yaml
+++ b/intake-catalogs/ua_ECCC-GEM_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/ECCC-GEM/ua_ECCC-GEM_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_ECCC-GEPS5_climo.p.yaml
+++ b/intake-catalogs/ua_ECCC-GEPS5_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/ECCC-GEPS5/ua_ECCC-GEPS5_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_ECCC-GEPS6_climo.p.yaml
+++ b/intake-catalogs/ua_ECCC-GEPS6_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/ECCC-GEPS6/ua_ECCC-GEPS6_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_ECCC-GEPS_climo.p.yaml
+++ b/intake-catalogs/ua_ECCC-GEPS_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/ECCC-GEPS/ua_ECCC-GEPS_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_EMC-GEFS_climo.p.yaml
+++ b/intake-catalogs/ua_EMC-GEFS_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/EMC-GEFS/ua_EMC-GEFS_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_ESRL-FIMr1p1_climo.p.yaml
+++ b/intake-catalogs/ua_ESRL-FIMr1p1_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/ESRL-FIMr1p1/ua_ESRL-FIMr1p1_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_GMAO-GEOS_V2p1_climo.p.yaml
+++ b/intake-catalogs/ua_GMAO-GEOS_V2p1_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/GMAO-GEOS_V2p1/ua_GMAO-GEOS_V2p1_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_NRL-NESM_climo.p.yaml
+++ b/intake-catalogs/ua_NRL-NESM_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/NRL-NESM/ua_NRL-NESM_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/intake-catalogs/ua_RSMAS-CCSM4_climo.p.yaml
+++ b/intake-catalogs/ua_RSMAS-CCSM4_climo.p.yaml
@@ -2,7 +2,7 @@ sources:
   netcdf:
     args:
       concat_dim: time
-      urlpath: /shared/subx/hindcast/ua200/daily/anoms/NRL-NESM/ua_200_NRL-NESM_*.anoms.daily.nc
+      urlpath: /shared/subx/hindcast/ua200/daily/climo/RSMAS-CCSM4/ua_RSMAS-CCSM4_*.climo.p.nc
       xarray_kwargs:
         combine: nested
         decode_times: false

--- a/subx_hindcast_ua200_daily_anoms_eccc-gem.html
+++ b/subx_hindcast_ua200_daily_anoms_eccc-gem.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_200_ECCC-GEM_.anoms.daily.e2.nc" class="list-group-item">
+                    <h4>ua_200_ECCC-GEM_.anoms.daily.e2.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_anoms_emc-gefs.html
+++ b/subx_hindcast_ua200_daily_anoms_emc-gefs.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_200_EMC-GEFS_.anoms.daily.e10.nc" class="list-group-item">
+                    <h4>ua_200_EMC-GEFS_.anoms.daily.e10.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_anoms_esrl-fimr1p1.html
+++ b/subx_hindcast_ua200_daily_anoms_esrl-fimr1p1.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_200_ESRL-FIMr1p1_.anoms.daily.e2.nc" class="list-group-item">
+                    <h4>ua_200_ESRL-FIMr1p1_.anoms.daily.e2.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_anoms_gmao-geos_v2p1.html
+++ b/subx_hindcast_ua200_daily_anoms_gmao-geos_v2p1.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_200_GMAO-GEOS_V2p1_.anoms.daily.e3.nc" class="list-group-item">
+                    <h4>ua_200_GMAO-GEOS_V2p1_.anoms.daily.e3.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_anoms_nrl-nesm.html
+++ b/subx_hindcast_ua200_daily_anoms_nrl-nesm.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_200_NRL-NESM_.anoms.daily.nc" class="list-group-item">
+                    <h4>ua_200_NRL-NESM_.anoms.daily.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_anoms_rsmas-ccsm4.html
+++ b/subx_hindcast_ua200_daily_anoms_rsmas-ccsm4.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_200_RSMAS-CCSM4_.anoms.daily.e2.nc" class="list-group-item">
+                    <h4>ua_200_RSMAS-CCSM4_.anoms.daily.e2.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_eccc-gem.html
+++ b/subx_hindcast_ua200_daily_climo_eccc-gem.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_ECCC-GEM_.climo.p.nc" class="list-group-item">
+                    <h4>ua_ECCC-GEM_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_eccc-geps.html
+++ b/subx_hindcast_ua200_daily_climo_eccc-geps.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_ECCC-GEPS_.climo.p.nc" class="list-group-item">
+                    <h4>ua_ECCC-GEPS_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_eccc-geps5.html
+++ b/subx_hindcast_ua200_daily_climo_eccc-geps5.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_ECCC-GEPS5_.climo.p.nc" class="list-group-item">
+                    <h4>ua_ECCC-GEPS5_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_eccc-geps6.html
+++ b/subx_hindcast_ua200_daily_climo_eccc-geps6.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_ECCC-GEPS6_.climo.p.nc" class="list-group-item">
+                    <h4>ua_ECCC-GEPS6_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_emc-gefs.html
+++ b/subx_hindcast_ua200_daily_climo_emc-gefs.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_EMC-GEFS_.climo.p.nc" class="list-group-item">
+                    <h4>ua_EMC-GEFS_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_esrl-fimr1p1.html
+++ b/subx_hindcast_ua200_daily_climo_esrl-fimr1p1.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_ESRL-FIMr1p1_.climo.p.nc" class="list-group-item">
+                    <h4>ua_ESRL-FIMr1p1_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_gmao-geos_v2p1.html
+++ b/subx_hindcast_ua200_daily_climo_gmao-geos_v2p1.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_GMAO-GEOS_V2p1_.climo.p.nc" class="list-group-item">
+                    <h4>ua_GMAO-GEOS_V2p1_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_nrl-nesm.html
+++ b/subx_hindcast_ua200_daily_climo_nrl-nesm.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_NRL-NESM_.climo.p.nc" class="list-group-item">
+                    <h4>ua_NRL-NESM_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/subx_hindcast_ua200_daily_climo_rsmas-ccsm4.html
+++ b/subx_hindcast_ua200_daily_climo_rsmas-ccsm4.html
@@ -73,7 +73,12 @@ list(cat)</code></pre>
         <h3>Datasets</h3>
         <div class="list-group">
         
-        <!--qazwsxxswzaq-->
+        <a href="ua_RSMAS-CCSM4_.climo.p.nc" class="list-group-item">
+                    <h4>ua_RSMAS-CCSM4_.climo.p.nc</h4>
+                    <p class="description"> </p>
+                </a> 
+
+<!--qazwsxxswzaq-->
 
 
 

--- a/ua_200_ECCC-GEM_.anoms.daily.e2.nc.html
+++ b/ua_200_ECCC-GEM_.anoms.daily.e2.nc.html
@@ -51,7 +51,7 @@
 
 <li><a href=subx_hindcast_ua200_daily_anoms>subx_hindcast_ua200_daily_anoms</a></li>
 
-<li><a href=subx_hindcast_ua200_daily_anoms_nrl-nesm>subx_hindcast_ua200_daily_anoms_nrl-nesm</a></li>
+<li><a href=subx_hindcast_ua200_daily_anoms_eccc-gem>subx_hindcast_ua200_daily_anoms_eccc-gem</a></li>
 
 
             <li class="active">SubX Anomalies</li>
@@ -64,7 +64,7 @@
 
         <h3>Load in Python</h3>
         <pre><code class="language-python">from intake import open_catalog<br>
-cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_NRL-NESM_anoms.daily.yaml")
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_ECCC-GEM_anoms.daily.e2.yaml")
 ds=cat.netcdf.read()</code></pre>
 
         <h3>Metadata</h3>
@@ -78,7 +78,7 @@ ds=cat.netcdf.read()</code></pre>
 
             <tr>
                 <td>location</td>
-                <td>/shared/subx/hindcast/ua200/daily/anoms/NRL-NESM</td>
+                <td>/shared/subx/hindcast/ua200/daily/anoms/ECCC-GEM</td>
             </tr>
 
             <tr>
@@ -88,13 +88,13 @@ ds=cat.netcdf.read()</code></pre>
 
             <tr>
                 <td>catalog_dir</td>
-                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_NRL-NESM_anoms.daily.yaml</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_ECCC-GEM_anoms.daily.e2.yaml</td>
             </tr>
     
 
             <tr>
                 <td>last updated </td>
-                <td>2018-07-14</td>
+                <td>2018-07-13</td>
             </tr>
 
 
@@ -461,22 +461,22 @@ dl.xr-attrs {
   fill: currentColor;
 }
 </style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
-Dimensions:  (lat: 181, lon: 360, time: 279405)
+Dimensions:  (lat: 181, lon: 360, time: 186912)
 Coordinates:
   * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
   * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
-  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 40.5 41.5 42.5 43.5 44.5
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 27.5 28.5 29.5 30.5 31.5
 Data variables:
-    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;
 Attributes:
     title:         SubX Anomalies
     long_title:    SubX Anomalies
     comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
     institution:   IRI
     source:        SubX IRI
-    CreationDate:  2018/07/14 07:17:37
+    CreationDate:  2018/03/25 21:08:04
     CreatedBy:     kpegion
-    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f1be56f8-cf7a-48a7-bf9a-c6ac4d666835' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f1be56f8-cf7a-48a7-bf9a-c6ac4d666835' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 279405</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4333d037-1eb3-4eee-b921-408db2c9f1f8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4333d037-1eb3-4eee-b921-408db2c9f1f8' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-9f5dc649-5581-4c0f-b827-076115a750fc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9f5dc649-5581-4c0f-b827-076115a750fc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bfdcc22f-e7d6-4d5f-a2d0-5aa3747dbac5' class='xr-var-data-in' type='checkbox'><label for='data-bfdcc22f-e7d6-4d5f-a2d0-5aa3747dbac5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-777a031e-0f79-4a91-a95f-37e3ddd0eab1' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-777a031e-0f79-4a91-a95f-37e3ddd0eab1' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 186912</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-bb74bbea-cad1-457e-bce3-df48ead481f4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bb74bbea-cad1-457e-bce3-df48ead481f4' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-b8bce919-fdc2-4bbd-877f-a8a00046e3a4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b8bce919-fdc2-4bbd-877f-a8a00046e3a4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9f6d820a-f9ce-4320-b210-4a37e9b2affc' class='xr-var-data-in' type='checkbox'><label for='data-9f6d820a-f9ce-4320-b210-4a37e9b2affc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
        -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
        -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
        -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
@@ -491,7 +491,7 @@ Attributes:
         54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
         66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
         78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
-        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-455b950b-5ee5-44c8-9906-92795e208705' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-455b950b-5ee5-44c8-9906-92795e208705' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-28d6b6a8-5041-4fc6-ad01-db31ecb0b541' class='xr-var-data-in' type='checkbox'><label for='data-28d6b6a8-5041-4fc6-ad01-db31ecb0b541' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-2c10cb96-b5da-484a-ad02-e243f4035bfd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2c10cb96-b5da-484a-ad02-e243f4035bfd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e2282ec9-2cec-4b13-b9a9-6aa3d71d0309' class='xr-var-data-in' type='checkbox'><label for='data-e2282ec9-2cec-4b13-b9a9-6aa3d71d0309' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-61f7f6f4-b0bb-4d6f-9d83-519f7d744f21' class='xr-section-summary-in' type='checkbox'  checked><label for='section-61f7f6f4-b0bb-4d6f-9d83-519f7d744f21' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-ee839924-4e45-4033-86ad-78e4b72d0c1d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee839924-4e45-4033-86ad-78e4b72d0c1d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b9ccdcf8-0938-4685-acad-fae5ef968a9e' class='xr-var-data-in' type='checkbox'><label for='data-b9ccdcf8-0938-4685-acad-fae5ef968a9e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m/s</dd></dl></div><div class='xr-var-data'><table>
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-83de5e09-6ff1-4be2-8c40-f1ebfd2268ab' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-83de5e09-6ff1-4be2-8c40-f1ebfd2268ab' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2e6b5a76-f72b-42cf-b98d-16b88686e7f1' class='xr-var-data-in' type='checkbox'><label for='data-2e6b5a76-f72b-42cf-b98d-16b88686e7f1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 29.5 30.5 31.5</div><input id='attrs-c70f9623-985e-4b0a-b870-05485bd627f8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c70f9623-985e-4b0a-b870-05485bd627f8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d926c9f0-44de-49cb-a2f2-b5c63e7b49d2' class='xr-var-data-in' type='checkbox'><label for='data-d926c9f0-44de-49cb-a2f2-b5c63e7b49d2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 29.5, 30.5, 31.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9f452492-0ee5-4f2e-804a-ac6bd943d6c0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9f452492-0ee5-4f2e-804a-ac6bd943d6c0' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-780cda83-8479-4891-a2da-31698e96dfc2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-780cda83-8479-4891-a2da-31698e96dfc2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bb9df461-7831-4255-8f7b-2d53bc5c39aa' class='xr-var-data-in' type='checkbox'><label for='data-bb9df461-7831-4255-8f7b-2d53bc5c39aa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m/s</dd></dl></div><div class='xr-var-data'><table>
 <tr>
 <td>
 <table>
@@ -499,9 +499,9 @@ Attributes:
     <tr><td> </td><th> Array </th><th> Chunk </th></tr>
   </thead>
   <tbody>
-    <tr><th> Bytes </th><td> 72.82 GB </td> <td> 11.73 MB </td></tr>
-    <tr><th> Shape </th><td> (279405, 181, 360) </td> <td> (45, 181, 360) </td></tr>
-    <tr><th> Count </th><td> 18627 Tasks </td><td> 6209 Chunks </td></tr>
+    <tr><th> Bytes </th><td> 48.72 GB </td> <td> 8.34 MB </td></tr>
+    <tr><th> Shape </th><td> (186912, 181, 360) </td> <td> (32, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 17523 Tasks </td><td> 5841 Chunks </td></tr>
     <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
   </tbody>
 </table>
@@ -563,9 +563,6 @@ Attributes:
   <line x1="10" y1="0" x2="10" y2="25" />
   <line x1="10" y1="0" x2="10" y2="25" />
   <line x1="10" y1="0" x2="10" y2="25" />
-  <line x1="10" y1="0" x2="10" y2="25" />
-  <line x1="10" y1="0" x2="10" y2="25" />
-  <line x1="10" y1="0" x2="10" y2="25" />
   <line x1="10" y1="0" x2="10" y2="26" />
   <line x1="10" y1="0" x2="10" y2="26" />
   <line x1="10" y1="0" x2="10" y2="26" />
@@ -600,11 +597,6 @@ Attributes:
   <line x1="10" y1="0" x2="10" y2="26" />
   <line x1="10" y1="0" x2="10" y2="26" />
   <line x1="10" y1="0" x2="10" y2="26" />
-  <line x1="10" y1="0" x2="10" y2="26" />
-  <line x1="10" y1="0" x2="10" y2="26" />
-  <line x1="11" y1="1" x2="11" y2="26" />
-  <line x1="11" y1="1" x2="11" y2="26" />
-  <line x1="11" y1="1" x2="11" y2="26" />
   <line x1="11" y1="1" x2="11" y2="26" />
   <line x1="11" y1="1" x2="11" y2="26" />
   <line x1="11" y1="1" x2="11" y2="26" />
@@ -688,11 +680,6 @@ Attributes:
   <line x1="11" y1="1" x2="11" y2="27" />
   <line x1="11" y1="1" x2="11" y2="27" />
   <line x1="11" y1="1" x2="11" y2="27" />
-  <line x1="11" y1="1" x2="11" y2="27" />
-  <line x1="11" y1="1" x2="11" y2="27" />
-  <line x1="12" y1="2" x2="12" y2="27" />
-  <line x1="12" y1="2" x2="12" y2="27" />
-  <line x1="12" y1="2" x2="12" y2="27" />
   <line x1="12" y1="2" x2="12" y2="27" />
   <line x1="12" y1="2" x2="12" y2="27" />
   <line x1="12" y1="2" x2="12" y2="27" />
@@ -776,12 +763,6 @@ Attributes:
   <line x1="12" y1="2" x2="12" y2="28" />
   <line x1="12" y1="2" x2="12" y2="28" />
   <line x1="12" y1="2" x2="12" y2="28" />
-  <line x1="12" y1="2" x2="12" y2="28" />
-  <line x1="12" y1="2" x2="12" y2="28" />
-  <line x1="13" y1="3" x2="13" y2="28" />
-  <line x1="13" y1="3" x2="13" y2="28" />
-  <line x1="13" y1="3" x2="13" y2="28" />
-  <line x1="13" y1="3" x2="13" y2="28" />
   <line x1="13" y1="3" x2="13" y2="28" />
   <line x1="13" y1="3" x2="13" y2="28" />
   <line x1="13" y1="3" x2="13" y2="28" />
@@ -864,11 +845,6 @@ Attributes:
   <line x1="13" y1="3" x2="13" y2="29" />
   <line x1="13" y1="3" x2="13" y2="29" />
   <line x1="13" y1="3" x2="13" y2="29" />
-  <line x1="13" y1="3" x2="13" y2="29" />
-  <line x1="13" y1="3" x2="13" y2="29" />
-  <line x1="14" y1="4" x2="14" y2="29" />
-  <line x1="14" y1="4" x2="14" y2="29" />
-  <line x1="14" y1="4" x2="14" y2="29" />
   <line x1="14" y1="4" x2="14" y2="29" />
   <line x1="14" y1="4" x2="14" y2="29" />
   <line x1="14" y1="4" x2="14" y2="29" />
@@ -952,11 +928,6 @@ Attributes:
   <line x1="14" y1="4" x2="14" y2="30" />
   <line x1="14" y1="4" x2="14" y2="30" />
   <line x1="14" y1="4" x2="14" y2="30" />
-  <line x1="14" y1="4" x2="14" y2="30" />
-  <line x1="14" y1="4" x2="14" y2="30" />
-  <line x1="15" y1="5" x2="15" y2="30" />
-  <line x1="15" y1="5" x2="15" y2="30" />
-  <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
@@ -1040,11 +1011,6 @@ Attributes:
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
-  <line x1="15" y1="5" x2="15" y2="31" />
-  <line x1="15" y1="5" x2="15" y2="31" />
-  <line x1="16" y1="6" x2="16" y2="31" />
-  <line x1="16" y1="6" x2="16" y2="31" />
-  <line x1="16" y1="6" x2="16" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
@@ -1128,12 +1094,6 @@ Attributes:
   <line x1="16" y1="6" x2="16" y2="32" />
   <line x1="16" y1="6" x2="16" y2="32" />
   <line x1="16" y1="6" x2="16" y2="32" />
-  <line x1="16" y1="6" x2="16" y2="32" />
-  <line x1="16" y1="6" x2="16" y2="32" />
-  <line x1="17" y1="7" x2="17" y2="32" />
-  <line x1="17" y1="7" x2="17" y2="32" />
-  <line x1="17" y1="7" x2="17" y2="32" />
-  <line x1="17" y1="7" x2="17" y2="32" />
   <line x1="17" y1="7" x2="17" y2="32" />
   <line x1="17" y1="7" x2="17" y2="32" />
   <line x1="17" y1="7" x2="17" y2="32" />
@@ -1216,11 +1176,6 @@ Attributes:
   <line x1="17" y1="7" x2="17" y2="33" />
   <line x1="17" y1="7" x2="17" y2="33" />
   <line x1="17" y1="7" x2="17" y2="33" />
-  <line x1="17" y1="7" x2="17" y2="33" />
-  <line x1="17" y1="7" x2="17" y2="33" />
-  <line x1="18" y1="8" x2="18" y2="33" />
-  <line x1="18" y1="8" x2="18" y2="33" />
-  <line x1="18" y1="8" x2="18" y2="33" />
   <line x1="18" y1="8" x2="18" y2="33" />
   <line x1="18" y1="8" x2="18" y2="33" />
   <line x1="18" y1="8" x2="18" y2="33" />
@@ -1304,11 +1259,6 @@ Attributes:
   <line x1="18" y1="8" x2="18" y2="34" />
   <line x1="18" y1="8" x2="18" y2="34" />
   <line x1="18" y1="8" x2="18" y2="34" />
-  <line x1="18" y1="8" x2="18" y2="34" />
-  <line x1="18" y1="8" x2="18" y2="34" />
-  <line x1="19" y1="9" x2="19" y2="34" />
-  <line x1="19" y1="9" x2="19" y2="34" />
-  <line x1="19" y1="9" x2="19" y2="34" />
   <line x1="19" y1="9" x2="19" y2="34" />
   <line x1="19" y1="9" x2="19" y2="34" />
   <line x1="19" y1="9" x2="19" y2="34" />
@@ -1392,11 +1342,6 @@ Attributes:
   <line x1="19" y1="9" x2="19" y2="35" />
   <line x1="19" y1="9" x2="19" y2="35" />
   <line x1="19" y1="9" x2="19" y2="35" />
-  <line x1="19" y1="9" x2="19" y2="35" />
-  <line x1="19" y1="9" x2="19" y2="35" />
-  <line x1="20" y1="10" x2="20" y2="35" />
-  <line x1="20" y1="10" x2="20" y2="35" />
-  <line x1="20" y1="10" x2="20" y2="35" />
   <line x1="20" y1="10" x2="20" y2="35" />
   <line x1="20" y1="10" x2="20" y2="35" />
   <line x1="20" y1="10" x2="20" y2="35" />
@@ -1480,12 +1425,6 @@ Attributes:
   <line x1="20" y1="10" x2="20" y2="36" />
   <line x1="20" y1="10" x2="20" y2="36" />
   <line x1="20" y1="10" x2="20" y2="36" />
-  <line x1="20" y1="10" x2="20" y2="36" />
-  <line x1="20" y1="10" x2="20" y2="36" />
-  <line x1="21" y1="11" x2="21" y2="36" />
-  <line x1="21" y1="11" x2="21" y2="36" />
-  <line x1="21" y1="11" x2="21" y2="36" />
-  <line x1="21" y1="11" x2="21" y2="36" />
   <line x1="21" y1="11" x2="21" y2="36" />
   <line x1="21" y1="11" x2="21" y2="36" />
   <line x1="21" y1="11" x2="21" y2="36" />
@@ -1568,11 +1507,6 @@ Attributes:
   <line x1="21" y1="11" x2="21" y2="37" />
   <line x1="21" y1="11" x2="21" y2="37" />
   <line x1="21" y1="11" x2="21" y2="37" />
-  <line x1="21" y1="11" x2="21" y2="37" />
-  <line x1="21" y1="11" x2="21" y2="37" />
-  <line x1="22" y1="12" x2="22" y2="37" />
-  <line x1="22" y1="12" x2="22" y2="37" />
-  <line x1="22" y1="12" x2="22" y2="37" />
   <line x1="22" y1="12" x2="22" y2="37" />
   <line x1="22" y1="12" x2="22" y2="37" />
   <line x1="22" y1="12" x2="22" y2="37" />
@@ -1656,11 +1590,6 @@ Attributes:
   <line x1="22" y1="12" x2="22" y2="38" />
   <line x1="22" y1="12" x2="22" y2="38" />
   <line x1="22" y1="12" x2="22" y2="38" />
-  <line x1="22" y1="12" x2="22" y2="38" />
-  <line x1="22" y1="12" x2="22" y2="38" />
-  <line x1="23" y1="13" x2="23" y2="38" />
-  <line x1="23" y1="13" x2="23" y2="38" />
-  <line x1="23" y1="13" x2="23" y2="38" />
   <line x1="23" y1="13" x2="23" y2="38" />
   <line x1="23" y1="13" x2="23" y2="38" />
   <line x1="23" y1="13" x2="23" y2="38" />
@@ -1744,11 +1673,6 @@ Attributes:
   <line x1="23" y1="13" x2="23" y2="39" />
   <line x1="23" y1="13" x2="23" y2="39" />
   <line x1="23" y1="13" x2="23" y2="39" />
-  <line x1="23" y1="13" x2="23" y2="39" />
-  <line x1="23" y1="13" x2="23" y2="39" />
-  <line x1="24" y1="14" x2="24" y2="39" />
-  <line x1="24" y1="14" x2="24" y2="39" />
-  <line x1="24" y1="14" x2="24" y2="39" />
   <line x1="24" y1="14" x2="24" y2="39" />
   <line x1="24" y1="14" x2="24" y2="39" />
   <line x1="24" y1="14" x2="24" y2="39" />
@@ -1832,12 +1756,6 @@ Attributes:
   <line x1="24" y1="14" x2="24" y2="40" />
   <line x1="24" y1="14" x2="24" y2="40" />
   <line x1="24" y1="14" x2="24" y2="40" />
-  <line x1="24" y1="14" x2="24" y2="40" />
-  <line x1="24" y1="14" x2="24" y2="40" />
-  <line x1="25" y1="15" x2="25" y2="40" />
-  <line x1="25" y1="15" x2="25" y2="40" />
-  <line x1="25" y1="15" x2="25" y2="40" />
-  <line x1="25" y1="15" x2="25" y2="40" />
   <line x1="25" y1="15" x2="25" y2="40" />
   <line x1="25" y1="15" x2="25" y2="40" />
   <line x1="25" y1="15" x2="25" y2="40" />
@@ -1920,11 +1838,6 @@ Attributes:
   <line x1="25" y1="15" x2="25" y2="41" />
   <line x1="25" y1="15" x2="25" y2="41" />
   <line x1="25" y1="15" x2="25" y2="41" />
-  <line x1="25" y1="15" x2="25" y2="41" />
-  <line x1="25" y1="15" x2="25" y2="41" />
-  <line x1="26" y1="16" x2="26" y2="41" />
-  <line x1="26" y1="16" x2="26" y2="41" />
-  <line x1="26" y1="16" x2="26" y2="41" />
   <line x1="26" y1="16" x2="26" y2="41" />
   <line x1="26" y1="16" x2="26" y2="41" />
   <line x1="26" y1="16" x2="26" y2="41" />
@@ -2008,11 +1921,6 @@ Attributes:
   <line x1="26" y1="16" x2="26" y2="42" />
   <line x1="26" y1="16" x2="26" y2="42" />
   <line x1="26" y1="16" x2="26" y2="42" />
-  <line x1="26" y1="16" x2="26" y2="42" />
-  <line x1="26" y1="16" x2="26" y2="42" />
-  <line x1="27" y1="17" x2="27" y2="42" />
-  <line x1="27" y1="17" x2="27" y2="42" />
-  <line x1="27" y1="17" x2="27" y2="42" />
   <line x1="27" y1="17" x2="27" y2="42" />
   <line x1="27" y1="17" x2="27" y2="42" />
   <line x1="27" y1="17" x2="27" y2="42" />
@@ -2096,10 +2004,6 @@ Attributes:
   <line x1="27" y1="17" x2="27" y2="43" />
   <line x1="27" y1="17" x2="27" y2="43" />
   <line x1="27" y1="17" x2="27" y2="43" />
-  <line x1="27" y1="17" x2="27" y2="43" />
-  <line x1="27" y1="17" x2="27" y2="43" />
-  <line x1="28" y1="18" x2="28" y2="43" />
-  <line x1="28" y1="18" x2="28" y2="43" />
   <line x1="28" y1="18" x2="28" y2="43" />
   <line x1="28" y1="18" x2="28" y2="43" />
   <line x1="28" y1="18" x2="28" y2="43" />
@@ -2183,12 +2087,6 @@ Attributes:
   <line x1="28" y1="18" x2="28" y2="44" />
   <line x1="28" y1="18" x2="28" y2="44" />
   <line x1="28" y1="18" x2="28" y2="44" />
-  <line x1="28" y1="18" x2="28" y2="44" />
-  <line x1="28" y1="18" x2="28" y2="44" />
-  <line x1="28" y1="18" x2="28" y2="44" />
-  <line x1="29" y1="19" x2="29" y2="44" />
-  <line x1="29" y1="19" x2="29" y2="44" />
-  <line x1="29" y1="19" x2="29" y2="44" />
   <line x1="29" y1="19" x2="29" y2="44" />
   <line x1="29" y1="19" x2="29" y2="44" />
   <line x1="29" y1="19" x2="29" y2="44" />
@@ -2271,11 +2169,6 @@ Attributes:
   <line x1="29" y1="19" x2="29" y2="45" />
   <line x1="29" y1="19" x2="29" y2="45" />
   <line x1="29" y1="19" x2="29" y2="45" />
-  <line x1="29" y1="19" x2="29" y2="45" />
-  <line x1="29" y1="19" x2="29" y2="45" />
-  <line x1="29" y1="19" x2="29" y2="45" />
-  <line x1="30" y1="20" x2="30" y2="45" />
-  <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
@@ -2359,11 +2252,6 @@ Attributes:
   <line x1="30" y1="20" x2="30" y2="46" />
   <line x1="30" y1="20" x2="30" y2="46" />
   <line x1="30" y1="20" x2="30" y2="46" />
-  <line x1="30" y1="20" x2="30" y2="46" />
-  <line x1="30" y1="20" x2="30" y2="46" />
-  <line x1="30" y1="20" x2="30" y2="46" />
-  <line x1="31" y1="21" x2="31" y2="46" />
-  <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
@@ -2447,11 +2335,6 @@ Attributes:
   <line x1="31" y1="21" x2="31" y2="47" />
   <line x1="31" y1="21" x2="31" y2="47" />
   <line x1="31" y1="21" x2="31" y2="47" />
-  <line x1="31" y1="21" x2="31" y2="47" />
-  <line x1="31" y1="21" x2="31" y2="47" />
-  <line x1="31" y1="21" x2="31" y2="47" />
-  <line x1="32" y1="22" x2="32" y2="47" />
-  <line x1="32" y1="22" x2="32" y2="47" />
   <line x1="32" y1="22" x2="32" y2="47" />
   <line x1="32" y1="22" x2="32" y2="47" />
   <line x1="32" y1="22" x2="32" y2="47" />
@@ -2535,12 +2418,6 @@ Attributes:
   <line x1="32" y1="22" x2="32" y2="48" />
   <line x1="32" y1="22" x2="32" y2="48" />
   <line x1="32" y1="22" x2="32" y2="48" />
-  <line x1="32" y1="22" x2="32" y2="48" />
-  <line x1="32" y1="22" x2="32" y2="48" />
-  <line x1="32" y1="22" x2="32" y2="48" />
-  <line x1="33" y1="23" x2="33" y2="48" />
-  <line x1="33" y1="23" x2="33" y2="48" />
-  <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
@@ -2623,11 +2500,6 @@ Attributes:
   <line x1="33" y1="23" x2="33" y2="49" />
   <line x1="33" y1="23" x2="33" y2="49" />
   <line x1="33" y1="23" x2="33" y2="49" />
-  <line x1="33" y1="23" x2="33" y2="49" />
-  <line x1="33" y1="23" x2="33" y2="49" />
-  <line x1="33" y1="23" x2="33" y2="49" />
-  <line x1="34" y1="24" x2="34" y2="49" />
-  <line x1="34" y1="24" x2="34" y2="49" />
   <line x1="34" y1="24" x2="34" y2="49" />
   <line x1="34" y1="24" x2="34" y2="49" />
   <line x1="34" y1="24" x2="34" y2="49" />
@@ -2711,11 +2583,6 @@ Attributes:
   <line x1="34" y1="24" x2="34" y2="50" />
   <line x1="34" y1="24" x2="34" y2="50" />
   <line x1="34" y1="24" x2="34" y2="50" />
-  <line x1="34" y1="24" x2="34" y2="50" />
-  <line x1="34" y1="24" x2="34" y2="50" />
-  <line x1="34" y1="24" x2="34" y2="50" />
-  <line x1="35" y1="25" x2="35" y2="50" />
-  <line x1="35" y1="25" x2="35" y2="50" />
   <line x1="35" y1="25" x2="35" y2="50" />
   <line x1="35" y1="25" x2="35" y2="50" />
   <line x1="35" y1="25" x2="35" y2="50" />
@@ -2799,11 +2666,6 @@ Attributes:
   <line x1="35" y1="25" x2="35" y2="51" />
   <line x1="35" y1="25" x2="35" y2="51" />
   <line x1="35" y1="25" x2="35" y2="51" />
-  <line x1="35" y1="25" x2="35" y2="51" />
-  <line x1="35" y1="25" x2="35" y2="51" />
-  <line x1="36" y1="26" x2="36" y2="51" />
-  <line x1="36" y1="26" x2="36" y2="51" />
-  <line x1="36" y1="26" x2="36" y2="51" />
   <line x1="36" y1="26" x2="36" y2="51" />
   <line x1="36" y1="26" x2="36" y2="51" />
   <line x1="36" y1="26" x2="36" y2="51" />
@@ -2887,12 +2749,6 @@ Attributes:
   <line x1="36" y1="26" x2="36" y2="52" />
   <line x1="36" y1="26" x2="36" y2="52" />
   <line x1="36" y1="26" x2="36" y2="52" />
-  <line x1="36" y1="26" x2="36" y2="52" />
-  <line x1="36" y1="26" x2="36" y2="52" />
-  <line x1="37" y1="27" x2="37" y2="52" />
-  <line x1="37" y1="27" x2="37" y2="52" />
-  <line x1="37" y1="27" x2="37" y2="52" />
-  <line x1="37" y1="27" x2="37" y2="52" />
   <line x1="37" y1="27" x2="37" y2="52" />
   <line x1="37" y1="27" x2="37" y2="52" />
   <line x1="37" y1="27" x2="37" y2="52" />
@@ -2975,11 +2831,6 @@ Attributes:
   <line x1="37" y1="27" x2="37" y2="53" />
   <line x1="37" y1="27" x2="37" y2="53" />
   <line x1="37" y1="27" x2="37" y2="53" />
-  <line x1="37" y1="27" x2="37" y2="53" />
-  <line x1="37" y1="27" x2="37" y2="53" />
-  <line x1="38" y1="28" x2="38" y2="53" />
-  <line x1="38" y1="28" x2="38" y2="53" />
-  <line x1="38" y1="28" x2="38" y2="53" />
   <line x1="38" y1="28" x2="38" y2="53" />
   <line x1="38" y1="28" x2="38" y2="53" />
   <line x1="38" y1="28" x2="38" y2="53" />
@@ -3063,11 +2914,6 @@ Attributes:
   <line x1="38" y1="28" x2="38" y2="54" />
   <line x1="38" y1="28" x2="38" y2="54" />
   <line x1="38" y1="28" x2="38" y2="54" />
-  <line x1="38" y1="28" x2="38" y2="54" />
-  <line x1="38" y1="28" x2="38" y2="54" />
-  <line x1="39" y1="29" x2="39" y2="54" />
-  <line x1="39" y1="29" x2="39" y2="54" />
-  <line x1="39" y1="29" x2="39" y2="54" />
   <line x1="39" y1="29" x2="39" y2="54" />
   <line x1="39" y1="29" x2="39" y2="54" />
   <line x1="39" y1="29" x2="39" y2="54" />
@@ -3151,11 +2997,6 @@ Attributes:
   <line x1="39" y1="29" x2="39" y2="55" />
   <line x1="39" y1="29" x2="39" y2="55" />
   <line x1="39" y1="29" x2="39" y2="55" />
-  <line x1="39" y1="29" x2="39" y2="55" />
-  <line x1="39" y1="29" x2="39" y2="55" />
-  <line x1="40" y1="30" x2="40" y2="55" />
-  <line x1="40" y1="30" x2="40" y2="55" />
-  <line x1="40" y1="30" x2="40" y2="55" />
   <line x1="40" y1="30" x2="40" y2="55" />
   <line x1="40" y1="30" x2="40" y2="55" />
   <line x1="40" y1="30" x2="40" y2="55" />
@@ -3239,12 +3080,6 @@ Attributes:
   <line x1="40" y1="30" x2="40" y2="56" />
   <line x1="40" y1="30" x2="40" y2="56" />
   <line x1="40" y1="30" x2="40" y2="56" />
-  <line x1="40" y1="30" x2="40" y2="56" />
-  <line x1="40" y1="30" x2="40" y2="56" />
-  <line x1="41" y1="31" x2="41" y2="56" />
-  <line x1="41" y1="31" x2="41" y2="56" />
-  <line x1="41" y1="31" x2="41" y2="56" />
-  <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
@@ -3327,11 +3162,6 @@ Attributes:
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
-  <line x1="41" y1="31" x2="41" y2="57" />
-  <line x1="41" y1="31" x2="41" y2="57" />
-  <line x1="42" y1="32" x2="42" y2="57" />
-  <line x1="42" y1="32" x2="42" y2="57" />
-  <line x1="42" y1="32" x2="42" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
@@ -3415,11 +3245,6 @@ Attributes:
   <line x1="42" y1="32" x2="42" y2="58" />
   <line x1="42" y1="32" x2="42" y2="58" />
   <line x1="42" y1="32" x2="42" y2="58" />
-  <line x1="42" y1="32" x2="42" y2="58" />
-  <line x1="42" y1="32" x2="42" y2="58" />
-  <line x1="43" y1="33" x2="43" y2="58" />
-  <line x1="43" y1="33" x2="43" y2="58" />
-  <line x1="43" y1="33" x2="43" y2="58" />
   <line x1="43" y1="33" x2="43" y2="58" />
   <line x1="43" y1="33" x2="43" y2="58" />
   <line x1="43" y1="33" x2="43" y2="58" />
@@ -3503,11 +3328,6 @@ Attributes:
   <line x1="43" y1="33" x2="43" y2="59" />
   <line x1="43" y1="33" x2="43" y2="59" />
   <line x1="43" y1="33" x2="43" y2="59" />
-  <line x1="43" y1="33" x2="43" y2="59" />
-  <line x1="43" y1="33" x2="43" y2="59" />
-  <line x1="44" y1="34" x2="44" y2="59" />
-  <line x1="44" y1="34" x2="44" y2="59" />
-  <line x1="44" y1="34" x2="44" y2="59" />
   <line x1="44" y1="34" x2="44" y2="59" />
   <line x1="44" y1="34" x2="44" y2="59" />
   <line x1="44" y1="34" x2="44" y2="59" />
@@ -3591,12 +3411,6 @@ Attributes:
   <line x1="44" y1="34" x2="44" y2="60" />
   <line x1="44" y1="34" x2="44" y2="60" />
   <line x1="44" y1="34" x2="44" y2="60" />
-  <line x1="44" y1="34" x2="44" y2="60" />
-  <line x1="44" y1="34" x2="44" y2="60" />
-  <line x1="45" y1="35" x2="45" y2="60" />
-  <line x1="45" y1="35" x2="45" y2="60" />
-  <line x1="45" y1="35" x2="45" y2="60" />
-  <line x1="45" y1="35" x2="45" y2="60" />
   <line x1="45" y1="35" x2="45" y2="60" />
   <line x1="45" y1="35" x2="45" y2="60" />
   <line x1="45" y1="35" x2="45" y2="60" />
@@ -3679,11 +3493,6 @@ Attributes:
   <line x1="45" y1="35" x2="45" y2="61" />
   <line x1="45" y1="35" x2="45" y2="61" />
   <line x1="45" y1="35" x2="45" y2="61" />
-  <line x1="45" y1="35" x2="45" y2="61" />
-  <line x1="45" y1="35" x2="45" y2="61" />
-  <line x1="46" y1="36" x2="46" y2="61" />
-  <line x1="46" y1="36" x2="46" y2="61" />
-  <line x1="46" y1="36" x2="46" y2="61" />
   <line x1="46" y1="36" x2="46" y2="61" />
   <line x1="46" y1="36" x2="46" y2="61" />
   <line x1="46" y1="36" x2="46" y2="61" />
@@ -3767,11 +3576,6 @@ Attributes:
   <line x1="46" y1="36" x2="46" y2="62" />
   <line x1="46" y1="36" x2="46" y2="62" />
   <line x1="46" y1="36" x2="46" y2="62" />
-  <line x1="46" y1="36" x2="46" y2="62" />
-  <line x1="46" y1="36" x2="46" y2="62" />
-  <line x1="47" y1="37" x2="47" y2="62" />
-  <line x1="47" y1="37" x2="47" y2="62" />
-  <line x1="47" y1="37" x2="47" y2="62" />
   <line x1="47" y1="37" x2="47" y2="62" />
   <line x1="47" y1="37" x2="47" y2="62" />
   <line x1="47" y1="37" x2="47" y2="62" />
@@ -3855,11 +3659,6 @@ Attributes:
   <line x1="47" y1="37" x2="47" y2="63" />
   <line x1="47" y1="37" x2="47" y2="63" />
   <line x1="47" y1="37" x2="47" y2="63" />
-  <line x1="47" y1="37" x2="47" y2="63" />
-  <line x1="47" y1="37" x2="47" y2="63" />
-  <line x1="48" y1="38" x2="48" y2="63" />
-  <line x1="48" y1="38" x2="48" y2="63" />
-  <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
@@ -3943,12 +3742,6 @@ Attributes:
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
-  <line x1="48" y1="38" x2="48" y2="64" />
-  <line x1="48" y1="38" x2="48" y2="64" />
-  <line x1="49" y1="39" x2="49" y2="64" />
-  <line x1="49" y1="39" x2="49" y2="64" />
-  <line x1="49" y1="39" x2="49" y2="64" />
-  <line x1="49" y1="39" x2="49" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
@@ -4031,11 +3824,6 @@ Attributes:
   <line x1="49" y1="39" x2="49" y2="65" />
   <line x1="49" y1="39" x2="49" y2="65" />
   <line x1="49" y1="39" x2="49" y2="65" />
-  <line x1="49" y1="39" x2="49" y2="65" />
-  <line x1="49" y1="39" x2="49" y2="65" />
-  <line x1="50" y1="40" x2="50" y2="65" />
-  <line x1="50" y1="40" x2="50" y2="65" />
-  <line x1="50" y1="40" x2="50" y2="65" />
   <line x1="50" y1="40" x2="50" y2="65" />
   <line x1="50" y1="40" x2="50" y2="65" />
   <line x1="50" y1="40" x2="50" y2="65" />
@@ -4119,11 +3907,6 @@ Attributes:
   <line x1="50" y1="40" x2="50" y2="66" />
   <line x1="50" y1="40" x2="50" y2="66" />
   <line x1="50" y1="40" x2="50" y2="66" />
-  <line x1="50" y1="40" x2="50" y2="66" />
-  <line x1="50" y1="40" x2="50" y2="66" />
-  <line x1="51" y1="41" x2="51" y2="66" />
-  <line x1="51" y1="41" x2="51" y2="66" />
-  <line x1="51" y1="41" x2="51" y2="66" />
   <line x1="51" y1="41" x2="51" y2="66" />
   <line x1="51" y1="41" x2="51" y2="66" />
   <line x1="51" y1="41" x2="51" y2="66" />
@@ -4207,12 +3990,6 @@ Attributes:
   <line x1="51" y1="41" x2="51" y2="67" />
   <line x1="51" y1="41" x2="51" y2="67" />
   <line x1="51" y1="41" x2="51" y2="67" />
-  <line x1="51" y1="41" x2="51" y2="67" />
-  <line x1="51" y1="41" x2="51" y2="67" />
-  <line x1="52" y1="42" x2="52" y2="67" />
-  <line x1="52" y1="42" x2="52" y2="67" />
-  <line x1="52" y1="42" x2="52" y2="67" />
-  <line x1="52" y1="42" x2="52" y2="67" />
   <line x1="52" y1="42" x2="52" y2="67" />
   <line x1="52" y1="42" x2="52" y2="67" />
   <line x1="52" y1="42" x2="52" y2="67" />
@@ -4296,10 +4073,6 @@ Attributes:
   <line x1="52" y1="42" x2="52" y2="68" />
   <line x1="52" y1="42" x2="52" y2="68" />
   <line x1="52" y1="42" x2="52" y2="68" />
-  <line x1="52" y1="42" x2="52" y2="68" />
-  <line x1="53" y1="43" x2="53" y2="68" />
-  <line x1="53" y1="43" x2="53" y2="68" />
-  <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="68" />
@@ -4382,11 +4155,6 @@ Attributes:
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
-  <line x1="53" y1="43" x2="53" y2="69" />
-  <line x1="53" y1="43" x2="53" y2="69" />
-  <line x1="53" y1="43" x2="53" y2="69" />
-  <line x1="54" y1="44" x2="54" y2="69" />
-  <line x1="54" y1="44" x2="54" y2="69" />
   <line x1="54" y1="44" x2="54" y2="69" />
   <line x1="54" y1="44" x2="54" y2="69" />
   <line x1="54" y1="44" x2="54" y2="69" />
@@ -4470,11 +4238,6 @@ Attributes:
   <line x1="54" y1="44" x2="54" y2="70" />
   <line x1="54" y1="44" x2="54" y2="70" />
   <line x1="54" y1="44" x2="54" y2="70" />
-  <line x1="54" y1="44" x2="54" y2="70" />
-  <line x1="54" y1="44" x2="54" y2="70" />
-  <line x1="54" y1="44" x2="54" y2="70" />
-  <line x1="55" y1="45" x2="55" y2="70" />
-  <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
@@ -4558,12 +4321,6 @@ Attributes:
   <line x1="55" y1="45" x2="55" y2="71" />
   <line x1="55" y1="45" x2="55" y2="71" />
   <line x1="55" y1="45" x2="55" y2="71" />
-  <line x1="55" y1="45" x2="55" y2="71" />
-  <line x1="55" y1="45" x2="55" y2="71" />
-  <line x1="55" y1="45" x2="55" y2="71" />
-  <line x1="56" y1="46" x2="56" y2="71" />
-  <line x1="56" y1="46" x2="56" y2="71" />
-  <line x1="56" y1="46" x2="56" y2="71" />
   <line x1="56" y1="46" x2="56" y2="71" />
   <line x1="56" y1="46" x2="56" y2="71" />
   <line x1="56" y1="46" x2="56" y2="71" />
@@ -4647,11 +4404,6 @@ Attributes:
   <line x1="56" y1="46" x2="56" y2="72" />
   <line x1="56" y1="46" x2="56" y2="72" />
   <line x1="56" y1="46" x2="56" y2="72" />
-  <line x1="56" y1="46" x2="56" y2="72" />
-  <line x1="56" y1="46" x2="56" y2="72" />
-  <line x1="57" y1="47" x2="57" y2="72" />
-  <line x1="57" y1="47" x2="57" y2="72" />
-  <line x1="57" y1="47" x2="57" y2="72" />
   <line x1="57" y1="47" x2="57" y2="72" />
   <line x1="57" y1="47" x2="57" y2="72" />
   <line x1="57" y1="47" x2="57" y2="72" />
@@ -4734,11 +4486,6 @@ Attributes:
   <line x1="57" y1="47" x2="57" y2="73" />
   <line x1="57" y1="47" x2="57" y2="73" />
   <line x1="57" y1="47" x2="57" y2="73" />
-  <line x1="57" y1="47" x2="57" y2="73" />
-  <line x1="57" y1="47" x2="57" y2="73" />
-  <line x1="57" y1="47" x2="57" y2="73" />
-  <line x1="58" y1="48" x2="58" y2="73" />
-  <line x1="58" y1="48" x2="58" y2="73" />
   <line x1="58" y1="48" x2="58" y2="73" />
   <line x1="58" y1="48" x2="58" y2="73" />
   <line x1="58" y1="48" x2="58" y2="73" />
@@ -4822,11 +4569,6 @@ Attributes:
   <line x1="58" y1="48" x2="58" y2="74" />
   <line x1="58" y1="48" x2="58" y2="74" />
   <line x1="58" y1="48" x2="58" y2="74" />
-  <line x1="58" y1="48" x2="58" y2="74" />
-  <line x1="58" y1="48" x2="58" y2="74" />
-  <line x1="58" y1="48" x2="58" y2="74" />
-  <line x1="59" y1="49" x2="59" y2="74" />
-  <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
@@ -4910,12 +4652,6 @@ Attributes:
   <line x1="59" y1="49" x2="59" y2="75" />
   <line x1="59" y1="49" x2="59" y2="75" />
   <line x1="59" y1="49" x2="59" y2="75" />
-  <line x1="59" y1="49" x2="59" y2="75" />
-  <line x1="59" y1="49" x2="59" y2="75" />
-  <line x1="59" y1="49" x2="59" y2="75" />
-  <line x1="60" y1="50" x2="60" y2="75" />
-  <line x1="60" y1="50" x2="60" y2="75" />
-  <line x1="60" y1="50" x2="60" y2="75" />
   <line x1="60" y1="50" x2="60" y2="75" />
   <line x1="60" y1="50" x2="60" y2="75" />
   <line x1="60" y1="50" x2="60" y2="75" />
@@ -4999,8 +4735,6 @@ Attributes:
   <line x1="60" y1="50" x2="60" y2="76" />
   <line x1="60" y1="50" x2="60" y2="76" />
   <line x1="60" y1="50" x2="60" y2="76" />
-  <line x1="60" y1="50" x2="60" y2="76" />
-  <line x1="60" y1="50" x2="60" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
@@ -5049,11 +4783,6 @@ Attributes:
   <line x1="61" y1="51" x2="61" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
-  <line x1="61" y1="51" x2="61" y2="76" />
-  <line x1="61" y1="51" x2="61" y2="76" />
-  <line x1="61" y1="51" x2="61" y2="76" />
-  <line x1="61" y1="51" x2="61" y2="77" />
-  <line x1="61" y1="51" x2="61" y2="77" />
   <line x1="61" y1="51" x2="61" y2="77" />
   <line x1="61" y1="51" x2="61" y2="77" />
   <line x1="61" y1="51" x2="61" y2="77" />
@@ -5137,9 +4866,6 @@ Attributes:
   <line x1="62" y1="52" x2="62" y2="77" />
   <line x1="62" y1="52" x2="62" y2="77" />
   <line x1="62" y1="52" x2="62" y2="77" />
-  <line x1="62" y1="52" x2="62" y2="77" />
-  <line x1="62" y1="52" x2="62" y2="77" />
-  <line x1="62" y1="52" x2="62" y2="77" />
   <line x1="62" y1="52" x2="62" y2="78" />
   <line x1="62" y1="52" x2="62" y2="78" />
   <line x1="62" y1="52" x2="62" y2="78" />
@@ -5174,11 +4900,6 @@ Attributes:
   <line x1="62" y1="52" x2="62" y2="78" />
   <line x1="62" y1="52" x2="62" y2="78" />
   <line x1="62" y1="52" x2="62" y2="78" />
-  <line x1="62" y1="52" x2="62" y2="78" />
-  <line x1="62" y1="52" x2="62" y2="78" />
-  <line x1="63" y1="53" x2="63" y2="78" />
-  <line x1="63" y1="53" x2="63" y2="78" />
-  <line x1="63" y1="53" x2="63" y2="78" />
   <line x1="63" y1="53" x2="63" y2="78" />
   <line x1="63" y1="53" x2="63" y2="78" />
   <line x1="63" y1="53" x2="63" y2="78" />
@@ -5262,12 +4983,6 @@ Attributes:
   <line x1="63" y1="53" x2="63" y2="79" />
   <line x1="63" y1="53" x2="63" y2="79" />
   <line x1="63" y1="53" x2="63" y2="79" />
-  <line x1="63" y1="53" x2="63" y2="79" />
-  <line x1="63" y1="53" x2="63" y2="79" />
-  <line x1="64" y1="54" x2="64" y2="79" />
-  <line x1="64" y1="54" x2="64" y2="79" />
-  <line x1="64" y1="54" x2="64" y2="79" />
-  <line x1="64" y1="54" x2="64" y2="79" />
   <line x1="64" y1="54" x2="64" y2="79" />
   <line x1="64" y1="54" x2="64" y2="79" />
   <line x1="64" y1="54" x2="64" y2="79" />
@@ -5351,11 +5066,6 @@ Attributes:
   <line x1="64" y1="54" x2="64" y2="80" />
   <line x1="64" y1="54" x2="64" y2="80" />
   <line x1="64" y1="54" x2="64" y2="80" />
-  <line x1="64" y1="54" x2="64" y2="80" />
-  <line x1="65" y1="55" x2="65" y2="80" />
-  <line x1="65" y1="55" x2="65" y2="80" />
-  <line x1="65" y1="55" x2="65" y2="80" />
-  <line x1="65" y1="55" x2="65" y2="80" />
   <line x1="65" y1="55" x2="65" y2="80" />
   <line x1="65" y1="55" x2="65" y2="80" />
   <line x1="65" y1="55" x2="65" y2="80" />
@@ -5438,11 +5148,6 @@ Attributes:
   <line x1="65" y1="55" x2="65" y2="81" />
   <line x1="65" y1="55" x2="65" y2="81" />
   <line x1="65" y1="55" x2="65" y2="81" />
-  <line x1="65" y1="55" x2="65" y2="81" />
-  <line x1="65" y1="55" x2="65" y2="81" />
-  <line x1="66" y1="56" x2="66" y2="81" />
-  <line x1="66" y1="56" x2="66" y2="81" />
-  <line x1="66" y1="56" x2="66" y2="81" />
   <line x1="66" y1="56" x2="66" y2="81" />
   <line x1="66" y1="56" x2="66" y2="81" />
   <line x1="66" y1="56" x2="66" y2="81" />
@@ -5526,11 +5231,6 @@ Attributes:
   <line x1="66" y1="56" x2="66" y2="82" />
   <line x1="66" y1="56" x2="66" y2="82" />
   <line x1="66" y1="56" x2="66" y2="82" />
-  <line x1="66" y1="56" x2="66" y2="82" />
-  <line x1="66" y1="56" x2="66" y2="82" />
-  <line x1="67" y1="57" x2="67" y2="82" />
-  <line x1="67" y1="57" x2="67" y2="82" />
-  <line x1="67" y1="57" x2="67" y2="82" />
   <line x1="67" y1="57" x2="67" y2="82" />
   <line x1="67" y1="57" x2="67" y2="82" />
   <line x1="67" y1="57" x2="67" y2="82" />
@@ -5614,12 +5314,6 @@ Attributes:
   <line x1="67" y1="57" x2="67" y2="83" />
   <line x1="67" y1="57" x2="67" y2="83" />
   <line x1="67" y1="57" x2="67" y2="83" />
-  <line x1="67" y1="57" x2="67" y2="83" />
-  <line x1="67" y1="57" x2="67" y2="83" />
-  <line x1="68" y1="58" x2="68" y2="83" />
-  <line x1="68" y1="58" x2="68" y2="83" />
-  <line x1="68" y1="58" x2="68" y2="83" />
-  <line x1="68" y1="58" x2="68" y2="83" />
   <line x1="68" y1="58" x2="68" y2="83" />
   <line x1="68" y1="58" x2="68" y2="83" />
   <line x1="68" y1="58" x2="68" y2="83" />
@@ -5703,11 +5397,6 @@ Attributes:
   <line x1="68" y1="58" x2="68" y2="84" />
   <line x1="68" y1="58" x2="68" y2="84" />
   <line x1="68" y1="58" x2="68" y2="84" />
-  <line x1="68" y1="58" x2="68" y2="84" />
-  <line x1="69" y1="59" x2="69" y2="84" />
-  <line x1="69" y1="59" x2="69" y2="84" />
-  <line x1="69" y1="59" x2="69" y2="84" />
-  <line x1="69" y1="59" x2="69" y2="84" />
   <line x1="69" y1="59" x2="69" y2="84" />
   <line x1="69" y1="59" x2="69" y2="84" />
   <line x1="69" y1="59" x2="69" y2="84" />
@@ -5790,11 +5479,6 @@ Attributes:
   <line x1="69" y1="59" x2="69" y2="85" />
   <line x1="69" y1="59" x2="69" y2="85" />
   <line x1="69" y1="59" x2="69" y2="85" />
-  <line x1="69" y1="59" x2="69" y2="85" />
-  <line x1="69" y1="59" x2="69" y2="85" />
-  <line x1="70" y1="60" x2="70" y2="85" />
-  <line x1="70" y1="60" x2="70" y2="85" />
-  <line x1="70" y1="60" x2="70" y2="85" />
   <line x1="70" y1="60" x2="70" y2="85" />
   <line x1="70" y1="60" x2="70" y2="85" />
   <line x1="70" y1="60" x2="70" y2="85" />
@@ -5878,11 +5562,6 @@ Attributes:
   <line x1="70" y1="60" x2="70" y2="86" />
   <line x1="70" y1="60" x2="70" y2="86" />
   <line x1="70" y1="60" x2="70" y2="86" />
-  <line x1="70" y1="60" x2="70" y2="86" />
-  <line x1="70" y1="60" x2="70" y2="86" />
-  <line x1="71" y1="61" x2="71" y2="86" />
-  <line x1="71" y1="61" x2="71" y2="86" />
-  <line x1="71" y1="61" x2="71" y2="86" />
   <line x1="71" y1="61" x2="71" y2="86" />
   <line x1="71" y1="61" x2="71" y2="86" />
   <line x1="71" y1="61" x2="71" y2="86" />
@@ -5966,12 +5645,6 @@ Attributes:
   <line x1="71" y1="61" x2="71" y2="87" />
   <line x1="71" y1="61" x2="71" y2="87" />
   <line x1="71" y1="61" x2="71" y2="87" />
-  <line x1="71" y1="61" x2="71" y2="87" />
-  <line x1="71" y1="61" x2="71" y2="87" />
-  <line x1="72" y1="62" x2="72" y2="87" />
-  <line x1="72" y1="62" x2="72" y2="87" />
-  <line x1="72" y1="62" x2="72" y2="87" />
-  <line x1="72" y1="62" x2="72" y2="87" />
   <line x1="72" y1="62" x2="72" y2="87" />
   <line x1="72" y1="62" x2="72" y2="87" />
   <line x1="72" y1="62" x2="72" y2="87" />
@@ -6055,11 +5728,6 @@ Attributes:
   <line x1="72" y1="62" x2="72" y2="88" />
   <line x1="72" y1="62" x2="72" y2="88" />
   <line x1="72" y1="62" x2="72" y2="88" />
-  <line x1="72" y1="62" x2="72" y2="88" />
-  <line x1="73" y1="63" x2="73" y2="88" />
-  <line x1="73" y1="63" x2="73" y2="88" />
-  <line x1="73" y1="63" x2="73" y2="88" />
-  <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
@@ -6142,11 +5810,6 @@ Attributes:
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
-  <line x1="73" y1="63" x2="73" y2="89" />
-  <line x1="73" y1="63" x2="73" y2="89" />
-  <line x1="74" y1="64" x2="74" y2="89" />
-  <line x1="74" y1="64" x2="74" y2="89" />
-  <line x1="74" y1="64" x2="74" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
@@ -6230,11 +5893,6 @@ Attributes:
   <line x1="74" y1="64" x2="74" y2="90" />
   <line x1="74" y1="64" x2="74" y2="90" />
   <line x1="74" y1="64" x2="74" y2="90" />
-  <line x1="74" y1="64" x2="74" y2="90" />
-  <line x1="74" y1="64" x2="74" y2="90" />
-  <line x1="75" y1="65" x2="75" y2="90" />
-  <line x1="75" y1="65" x2="75" y2="90" />
-  <line x1="75" y1="65" x2="75" y2="90" />
   <line x1="75" y1="65" x2="75" y2="90" />
   <line x1="75" y1="65" x2="75" y2="90" />
   <line x1="75" y1="65" x2="75" y2="90" />
@@ -6318,12 +5976,6 @@ Attributes:
   <line x1="75" y1="65" x2="75" y2="91" />
   <line x1="75" y1="65" x2="75" y2="91" />
   <line x1="75" y1="65" x2="75" y2="91" />
-  <line x1="75" y1="65" x2="75" y2="91" />
-  <line x1="75" y1="65" x2="75" y2="91" />
-  <line x1="76" y1="66" x2="76" y2="91" />
-  <line x1="76" y1="66" x2="76" y2="91" />
-  <line x1="76" y1="66" x2="76" y2="91" />
-  <line x1="76" y1="66" x2="76" y2="91" />
   <line x1="76" y1="66" x2="76" y2="91" />
   <line x1="76" y1="66" x2="76" y2="91" />
   <line x1="76" y1="66" x2="76" y2="91" />
@@ -6407,11 +6059,6 @@ Attributes:
   <line x1="76" y1="66" x2="76" y2="92" />
   <line x1="76" y1="66" x2="76" y2="92" />
   <line x1="76" y1="66" x2="76" y2="92" />
-  <line x1="76" y1="66" x2="76" y2="92" />
-  <line x1="77" y1="67" x2="77" y2="92" />
-  <line x1="77" y1="67" x2="77" y2="92" />
-  <line x1="77" y1="67" x2="77" y2="92" />
-  <line x1="77" y1="67" x2="77" y2="92" />
   <line x1="77" y1="67" x2="77" y2="92" />
   <line x1="77" y1="67" x2="77" y2="92" />
   <line x1="77" y1="67" x2="77" y2="92" />
@@ -6494,11 +6141,6 @@ Attributes:
   <line x1="77" y1="67" x2="77" y2="93" />
   <line x1="77" y1="67" x2="77" y2="93" />
   <line x1="77" y1="67" x2="77" y2="93" />
-  <line x1="77" y1="67" x2="77" y2="93" />
-  <line x1="77" y1="67" x2="77" y2="93" />
-  <line x1="78" y1="68" x2="78" y2="93" />
-  <line x1="78" y1="68" x2="78" y2="93" />
-  <line x1="78" y1="68" x2="78" y2="93" />
   <line x1="78" y1="68" x2="78" y2="93" />
   <line x1="78" y1="68" x2="78" y2="93" />
   <line x1="78" y1="68" x2="78" y2="93" />
@@ -6582,10 +6224,6 @@ Attributes:
   <line x1="78" y1="68" x2="78" y2="94" />
   <line x1="78" y1="68" x2="78" y2="94" />
   <line x1="78" y1="68" x2="78" y2="94" />
-  <line x1="78" y1="68" x2="78" y2="94" />
-  <line x1="78" y1="68" x2="78" y2="94" />
-  <line x1="79" y1="69" x2="79" y2="94" />
-  <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="94" />
@@ -6669,12 +6307,6 @@ Attributes:
   <line x1="79" y1="69" x2="79" y2="95" />
   <line x1="79" y1="69" x2="79" y2="95" />
   <line x1="79" y1="69" x2="79" y2="95" />
-  <line x1="79" y1="69" x2="79" y2="95" />
-  <line x1="79" y1="69" x2="79" y2="95" />
-  <line x1="79" y1="69" x2="79" y2="95" />
-  <line x1="80" y1="70" x2="80" y2="95" />
-  <line x1="80" y1="70" x2="80" y2="95" />
-  <line x1="80" y1="70" x2="80" y2="95" />
   <line x1="80" y1="70" x2="80" y2="95" />
   <line x1="80" y1="70" x2="80" y2="95" />
   <line x1="80" y1="70" x2="80" y2="95" />
@@ -6778,9 +6410,6 @@ Attributes:
   <line x1="10" y1="0" x2="35" y2="0" />
   <line x1="10" y1="0" x2="35" y2="0" />
   <line x1="10" y1="0" x2="35" y2="0" />
-  <line x1="10" y1="0" x2="35" y2="0" />
-  <line x1="10" y1="0" x2="35" y2="0" />
-  <line x1="10" y1="0" x2="35" y2="0" />
   <line x1="10" y1="0" x2="36" y2="0" />
   <line x1="10" y1="0" x2="36" y2="0" />
   <line x1="10" y1="0" x2="36" y2="0" />
@@ -6815,11 +6444,6 @@ Attributes:
   <line x1="10" y1="0" x2="36" y2="0" />
   <line x1="10" y1="0" x2="36" y2="0" />
   <line x1="10" y1="0" x2="36" y2="0" />
-  <line x1="10" y1="0" x2="36" y2="0" />
-  <line x1="10" y1="0" x2="36" y2="0" />
-  <line x1="11" y1="1" x2="36" y2="1" />
-  <line x1="11" y1="1" x2="36" y2="1" />
-  <line x1="11" y1="1" x2="36" y2="1" />
   <line x1="11" y1="1" x2="36" y2="1" />
   <line x1="11" y1="1" x2="36" y2="1" />
   <line x1="11" y1="1" x2="36" y2="1" />
@@ -6903,11 +6527,6 @@ Attributes:
   <line x1="11" y1="1" x2="37" y2="1" />
   <line x1="11" y1="1" x2="37" y2="1" />
   <line x1="11" y1="1" x2="37" y2="1" />
-  <line x1="11" y1="1" x2="37" y2="1" />
-  <line x1="11" y1="1" x2="37" y2="1" />
-  <line x1="12" y1="2" x2="37" y2="2" />
-  <line x1="12" y1="2" x2="37" y2="2" />
-  <line x1="12" y1="2" x2="37" y2="2" />
   <line x1="12" y1="2" x2="37" y2="2" />
   <line x1="12" y1="2" x2="37" y2="2" />
   <line x1="12" y1="2" x2="37" y2="2" />
@@ -6991,12 +6610,6 @@ Attributes:
   <line x1="12" y1="2" x2="38" y2="2" />
   <line x1="12" y1="2" x2="38" y2="2" />
   <line x1="12" y1="2" x2="38" y2="2" />
-  <line x1="12" y1="2" x2="38" y2="2" />
-  <line x1="12" y1="2" x2="38" y2="2" />
-  <line x1="13" y1="3" x2="38" y2="3" />
-  <line x1="13" y1="3" x2="38" y2="3" />
-  <line x1="13" y1="3" x2="38" y2="3" />
-  <line x1="13" y1="3" x2="38" y2="3" />
   <line x1="13" y1="3" x2="38" y2="3" />
   <line x1="13" y1="3" x2="38" y2="3" />
   <line x1="13" y1="3" x2="38" y2="3" />
@@ -7079,11 +6692,6 @@ Attributes:
   <line x1="13" y1="3" x2="39" y2="3" />
   <line x1="13" y1="3" x2="39" y2="3" />
   <line x1="13" y1="3" x2="39" y2="3" />
-  <line x1="13" y1="3" x2="39" y2="3" />
-  <line x1="13" y1="3" x2="39" y2="3" />
-  <line x1="14" y1="4" x2="39" y2="4" />
-  <line x1="14" y1="4" x2="39" y2="4" />
-  <line x1="14" y1="4" x2="39" y2="4" />
   <line x1="14" y1="4" x2="39" y2="4" />
   <line x1="14" y1="4" x2="39" y2="4" />
   <line x1="14" y1="4" x2="39" y2="4" />
@@ -7167,11 +6775,6 @@ Attributes:
   <line x1="14" y1="4" x2="40" y2="4" />
   <line x1="14" y1="4" x2="40" y2="4" />
   <line x1="14" y1="4" x2="40" y2="4" />
-  <line x1="14" y1="4" x2="40" y2="4" />
-  <line x1="14" y1="4" x2="40" y2="4" />
-  <line x1="15" y1="5" x2="40" y2="5" />
-  <line x1="15" y1="5" x2="40" y2="5" />
-  <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="40" y2="5" />
@@ -7255,11 +6858,6 @@ Attributes:
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
-  <line x1="15" y1="5" x2="41" y2="5" />
-  <line x1="15" y1="5" x2="41" y2="5" />
-  <line x1="16" y1="6" x2="41" y2="6" />
-  <line x1="16" y1="6" x2="41" y2="6" />
-  <line x1="16" y1="6" x2="41" y2="6" />
   <line x1="16" y1="6" x2="41" y2="6" />
   <line x1="16" y1="6" x2="41" y2="6" />
   <line x1="16" y1="6" x2="41" y2="6" />
@@ -7343,12 +6941,6 @@ Attributes:
   <line x1="16" y1="6" x2="42" y2="6" />
   <line x1="16" y1="6" x2="42" y2="6" />
   <line x1="16" y1="6" x2="42" y2="6" />
-  <line x1="16" y1="6" x2="42" y2="6" />
-  <line x1="16" y1="6" x2="42" y2="6" />
-  <line x1="17" y1="7" x2="42" y2="7" />
-  <line x1="17" y1="7" x2="42" y2="7" />
-  <line x1="17" y1="7" x2="42" y2="7" />
-  <line x1="17" y1="7" x2="42" y2="7" />
   <line x1="17" y1="7" x2="42" y2="7" />
   <line x1="17" y1="7" x2="42" y2="7" />
   <line x1="17" y1="7" x2="42" y2="7" />
@@ -7431,11 +7023,6 @@ Attributes:
   <line x1="17" y1="7" x2="43" y2="7" />
   <line x1="17" y1="7" x2="43" y2="7" />
   <line x1="17" y1="7" x2="43" y2="7" />
-  <line x1="17" y1="7" x2="43" y2="7" />
-  <line x1="17" y1="7" x2="43" y2="7" />
-  <line x1="18" y1="8" x2="43" y2="8" />
-  <line x1="18" y1="8" x2="43" y2="8" />
-  <line x1="18" y1="8" x2="43" y2="8" />
   <line x1="18" y1="8" x2="43" y2="8" />
   <line x1="18" y1="8" x2="43" y2="8" />
   <line x1="18" y1="8" x2="43" y2="8" />
@@ -7519,11 +7106,6 @@ Attributes:
   <line x1="18" y1="8" x2="44" y2="8" />
   <line x1="18" y1="8" x2="44" y2="8" />
   <line x1="18" y1="8" x2="44" y2="8" />
-  <line x1="18" y1="8" x2="44" y2="8" />
-  <line x1="18" y1="8" x2="44" y2="8" />
-  <line x1="19" y1="9" x2="44" y2="9" />
-  <line x1="19" y1="9" x2="44" y2="9" />
-  <line x1="19" y1="9" x2="44" y2="9" />
   <line x1="19" y1="9" x2="44" y2="9" />
   <line x1="19" y1="9" x2="44" y2="9" />
   <line x1="19" y1="9" x2="44" y2="9" />
@@ -7607,11 +7189,6 @@ Attributes:
   <line x1="19" y1="9" x2="45" y2="9" />
   <line x1="19" y1="9" x2="45" y2="9" />
   <line x1="19" y1="9" x2="45" y2="9" />
-  <line x1="19" y1="9" x2="45" y2="9" />
-  <line x1="19" y1="9" x2="45" y2="9" />
-  <line x1="20" y1="10" x2="45" y2="10" />
-  <line x1="20" y1="10" x2="45" y2="10" />
-  <line x1="20" y1="10" x2="45" y2="10" />
   <line x1="20" y1="10" x2="45" y2="10" />
   <line x1="20" y1="10" x2="45" y2="10" />
   <line x1="20" y1="10" x2="45" y2="10" />
@@ -7695,12 +7272,6 @@ Attributes:
   <line x1="20" y1="10" x2="46" y2="10" />
   <line x1="20" y1="10" x2="46" y2="10" />
   <line x1="20" y1="10" x2="46" y2="10" />
-  <line x1="20" y1="10" x2="46" y2="10" />
-  <line x1="20" y1="10" x2="46" y2="10" />
-  <line x1="21" y1="11" x2="46" y2="11" />
-  <line x1="21" y1="11" x2="46" y2="11" />
-  <line x1="21" y1="11" x2="46" y2="11" />
-  <line x1="21" y1="11" x2="46" y2="11" />
   <line x1="21" y1="11" x2="46" y2="11" />
   <line x1="21" y1="11" x2="46" y2="11" />
   <line x1="21" y1="11" x2="46" y2="11" />
@@ -7783,11 +7354,6 @@ Attributes:
   <line x1="21" y1="11" x2="47" y2="11" />
   <line x1="21" y1="11" x2="47" y2="11" />
   <line x1="21" y1="11" x2="47" y2="11" />
-  <line x1="21" y1="11" x2="47" y2="11" />
-  <line x1="21" y1="11" x2="47" y2="11" />
-  <line x1="22" y1="12" x2="47" y2="12" />
-  <line x1="22" y1="12" x2="47" y2="12" />
-  <line x1="22" y1="12" x2="47" y2="12" />
   <line x1="22" y1="12" x2="47" y2="12" />
   <line x1="22" y1="12" x2="47" y2="12" />
   <line x1="22" y1="12" x2="47" y2="12" />
@@ -7871,11 +7437,6 @@ Attributes:
   <line x1="22" y1="12" x2="48" y2="12" />
   <line x1="22" y1="12" x2="48" y2="12" />
   <line x1="22" y1="12" x2="48" y2="12" />
-  <line x1="22" y1="12" x2="48" y2="12" />
-  <line x1="22" y1="12" x2="48" y2="12" />
-  <line x1="23" y1="13" x2="48" y2="13" />
-  <line x1="23" y1="13" x2="48" y2="13" />
-  <line x1="23" y1="13" x2="48" y2="13" />
   <line x1="23" y1="13" x2="48" y2="13" />
   <line x1="23" y1="13" x2="48" y2="13" />
   <line x1="23" y1="13" x2="48" y2="13" />
@@ -7959,11 +7520,6 @@ Attributes:
   <line x1="23" y1="13" x2="49" y2="13" />
   <line x1="23" y1="13" x2="49" y2="13" />
   <line x1="23" y1="13" x2="49" y2="13" />
-  <line x1="23" y1="13" x2="49" y2="13" />
-  <line x1="23" y1="13" x2="49" y2="13" />
-  <line x1="24" y1="14" x2="49" y2="14" />
-  <line x1="24" y1="14" x2="49" y2="14" />
-  <line x1="24" y1="14" x2="49" y2="14" />
   <line x1="24" y1="14" x2="49" y2="14" />
   <line x1="24" y1="14" x2="49" y2="14" />
   <line x1="24" y1="14" x2="49" y2="14" />
@@ -8047,12 +7603,6 @@ Attributes:
   <line x1="24" y1="14" x2="50" y2="14" />
   <line x1="24" y1="14" x2="50" y2="14" />
   <line x1="24" y1="14" x2="50" y2="14" />
-  <line x1="24" y1="14" x2="50" y2="14" />
-  <line x1="24" y1="14" x2="50" y2="14" />
-  <line x1="25" y1="15" x2="50" y2="15" />
-  <line x1="25" y1="15" x2="50" y2="15" />
-  <line x1="25" y1="15" x2="50" y2="15" />
-  <line x1="25" y1="15" x2="50" y2="15" />
   <line x1="25" y1="15" x2="50" y2="15" />
   <line x1="25" y1="15" x2="50" y2="15" />
   <line x1="25" y1="15" x2="50" y2="15" />
@@ -8135,11 +7685,6 @@ Attributes:
   <line x1="25" y1="15" x2="51" y2="15" />
   <line x1="25" y1="15" x2="51" y2="15" />
   <line x1="25" y1="15" x2="51" y2="15" />
-  <line x1="25" y1="15" x2="51" y2="15" />
-  <line x1="25" y1="15" x2="51" y2="15" />
-  <line x1="26" y1="16" x2="51" y2="16" />
-  <line x1="26" y1="16" x2="51" y2="16" />
-  <line x1="26" y1="16" x2="51" y2="16" />
   <line x1="26" y1="16" x2="51" y2="16" />
   <line x1="26" y1="16" x2="51" y2="16" />
   <line x1="26" y1="16" x2="51" y2="16" />
@@ -8223,11 +7768,6 @@ Attributes:
   <line x1="26" y1="16" x2="52" y2="16" />
   <line x1="26" y1="16" x2="52" y2="16" />
   <line x1="26" y1="16" x2="52" y2="16" />
-  <line x1="26" y1="16" x2="52" y2="16" />
-  <line x1="26" y1="16" x2="52" y2="16" />
-  <line x1="27" y1="17" x2="52" y2="17" />
-  <line x1="27" y1="17" x2="52" y2="17" />
-  <line x1="27" y1="17" x2="52" y2="17" />
   <line x1="27" y1="17" x2="52" y2="17" />
   <line x1="27" y1="17" x2="52" y2="17" />
   <line x1="27" y1="17" x2="52" y2="17" />
@@ -8311,10 +7851,6 @@ Attributes:
   <line x1="27" y1="17" x2="53" y2="17" />
   <line x1="27" y1="17" x2="53" y2="17" />
   <line x1="27" y1="17" x2="53" y2="17" />
-  <line x1="27" y1="17" x2="53" y2="17" />
-  <line x1="27" y1="17" x2="53" y2="17" />
-  <line x1="28" y1="18" x2="53" y2="18" />
-  <line x1="28" y1="18" x2="53" y2="18" />
   <line x1="28" y1="18" x2="53" y2="18" />
   <line x1="28" y1="18" x2="53" y2="18" />
   <line x1="28" y1="18" x2="53" y2="18" />
@@ -8398,12 +7934,6 @@ Attributes:
   <line x1="28" y1="18" x2="54" y2="18" />
   <line x1="28" y1="18" x2="54" y2="18" />
   <line x1="28" y1="18" x2="54" y2="18" />
-  <line x1="28" y1="18" x2="54" y2="18" />
-  <line x1="28" y1="18" x2="54" y2="18" />
-  <line x1="28" y1="18" x2="54" y2="18" />
-  <line x1="29" y1="19" x2="54" y2="19" />
-  <line x1="29" y1="19" x2="54" y2="19" />
-  <line x1="29" y1="19" x2="54" y2="19" />
   <line x1="29" y1="19" x2="54" y2="19" />
   <line x1="29" y1="19" x2="54" y2="19" />
   <line x1="29" y1="19" x2="54" y2="19" />
@@ -8486,11 +8016,6 @@ Attributes:
   <line x1="29" y1="19" x2="55" y2="19" />
   <line x1="29" y1="19" x2="55" y2="19" />
   <line x1="29" y1="19" x2="55" y2="19" />
-  <line x1="29" y1="19" x2="55" y2="19" />
-  <line x1="29" y1="19" x2="55" y2="19" />
-  <line x1="29" y1="19" x2="55" y2="19" />
-  <line x1="30" y1="20" x2="55" y2="20" />
-  <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
@@ -8574,11 +8099,6 @@ Attributes:
   <line x1="30" y1="20" x2="56" y2="20" />
   <line x1="30" y1="20" x2="56" y2="20" />
   <line x1="30" y1="20" x2="56" y2="20" />
-  <line x1="30" y1="20" x2="56" y2="20" />
-  <line x1="30" y1="20" x2="56" y2="20" />
-  <line x1="30" y1="20" x2="56" y2="20" />
-  <line x1="31" y1="21" x2="56" y2="21" />
-  <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
@@ -8662,11 +8182,6 @@ Attributes:
   <line x1="31" y1="21" x2="57" y2="21" />
   <line x1="31" y1="21" x2="57" y2="21" />
   <line x1="31" y1="21" x2="57" y2="21" />
-  <line x1="31" y1="21" x2="57" y2="21" />
-  <line x1="31" y1="21" x2="57" y2="21" />
-  <line x1="31" y1="21" x2="57" y2="21" />
-  <line x1="32" y1="22" x2="57" y2="22" />
-  <line x1="32" y1="22" x2="57" y2="22" />
   <line x1="32" y1="22" x2="57" y2="22" />
   <line x1="32" y1="22" x2="57" y2="22" />
   <line x1="32" y1="22" x2="57" y2="22" />
@@ -8750,12 +8265,6 @@ Attributes:
   <line x1="32" y1="22" x2="58" y2="22" />
   <line x1="32" y1="22" x2="58" y2="22" />
   <line x1="32" y1="22" x2="58" y2="22" />
-  <line x1="32" y1="22" x2="58" y2="22" />
-  <line x1="32" y1="22" x2="58" y2="22" />
-  <line x1="32" y1="22" x2="58" y2="22" />
-  <line x1="33" y1="23" x2="58" y2="23" />
-  <line x1="33" y1="23" x2="58" y2="23" />
-  <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="58" y2="23" />
@@ -8838,11 +8347,6 @@ Attributes:
   <line x1="33" y1="23" x2="59" y2="23" />
   <line x1="33" y1="23" x2="59" y2="23" />
   <line x1="33" y1="23" x2="59" y2="23" />
-  <line x1="33" y1="23" x2="59" y2="23" />
-  <line x1="33" y1="23" x2="59" y2="23" />
-  <line x1="33" y1="23" x2="59" y2="23" />
-  <line x1="34" y1="24" x2="59" y2="24" />
-  <line x1="34" y1="24" x2="59" y2="24" />
   <line x1="34" y1="24" x2="59" y2="24" />
   <line x1="34" y1="24" x2="59" y2="24" />
   <line x1="34" y1="24" x2="59" y2="24" />
@@ -8926,11 +8430,6 @@ Attributes:
   <line x1="34" y1="24" x2="60" y2="24" />
   <line x1="34" y1="24" x2="60" y2="24" />
   <line x1="34" y1="24" x2="60" y2="24" />
-  <line x1="34" y1="24" x2="60" y2="24" />
-  <line x1="34" y1="24" x2="60" y2="24" />
-  <line x1="34" y1="24" x2="60" y2="24" />
-  <line x1="35" y1="25" x2="60" y2="25" />
-  <line x1="35" y1="25" x2="60" y2="25" />
   <line x1="35" y1="25" x2="60" y2="25" />
   <line x1="35" y1="25" x2="60" y2="25" />
   <line x1="35" y1="25" x2="60" y2="25" />
@@ -9014,11 +8513,6 @@ Attributes:
   <line x1="35" y1="25" x2="61" y2="25" />
   <line x1="35" y1="25" x2="61" y2="25" />
   <line x1="35" y1="25" x2="61" y2="25" />
-  <line x1="35" y1="25" x2="61" y2="25" />
-  <line x1="35" y1="25" x2="61" y2="25" />
-  <line x1="36" y1="26" x2="61" y2="26" />
-  <line x1="36" y1="26" x2="61" y2="26" />
-  <line x1="36" y1="26" x2="61" y2="26" />
   <line x1="36" y1="26" x2="61" y2="26" />
   <line x1="36" y1="26" x2="61" y2="26" />
   <line x1="36" y1="26" x2="61" y2="26" />
@@ -9102,12 +8596,6 @@ Attributes:
   <line x1="36" y1="26" x2="62" y2="26" />
   <line x1="36" y1="26" x2="62" y2="26" />
   <line x1="36" y1="26" x2="62" y2="26" />
-  <line x1="36" y1="26" x2="62" y2="26" />
-  <line x1="36" y1="26" x2="62" y2="26" />
-  <line x1="37" y1="27" x2="62" y2="27" />
-  <line x1="37" y1="27" x2="62" y2="27" />
-  <line x1="37" y1="27" x2="62" y2="27" />
-  <line x1="37" y1="27" x2="62" y2="27" />
   <line x1="37" y1="27" x2="62" y2="27" />
   <line x1="37" y1="27" x2="62" y2="27" />
   <line x1="37" y1="27" x2="62" y2="27" />
@@ -9190,11 +8678,6 @@ Attributes:
   <line x1="37" y1="27" x2="63" y2="27" />
   <line x1="37" y1="27" x2="63" y2="27" />
   <line x1="37" y1="27" x2="63" y2="27" />
-  <line x1="37" y1="27" x2="63" y2="27" />
-  <line x1="37" y1="27" x2="63" y2="27" />
-  <line x1="38" y1="28" x2="63" y2="28" />
-  <line x1="38" y1="28" x2="63" y2="28" />
-  <line x1="38" y1="28" x2="63" y2="28" />
   <line x1="38" y1="28" x2="63" y2="28" />
   <line x1="38" y1="28" x2="63" y2="28" />
   <line x1="38" y1="28" x2="63" y2="28" />
@@ -9278,11 +8761,6 @@ Attributes:
   <line x1="38" y1="28" x2="64" y2="28" />
   <line x1="38" y1="28" x2="64" y2="28" />
   <line x1="38" y1="28" x2="64" y2="28" />
-  <line x1="38" y1="28" x2="64" y2="28" />
-  <line x1="38" y1="28" x2="64" y2="28" />
-  <line x1="39" y1="29" x2="64" y2="29" />
-  <line x1="39" y1="29" x2="64" y2="29" />
-  <line x1="39" y1="29" x2="64" y2="29" />
   <line x1="39" y1="29" x2="64" y2="29" />
   <line x1="39" y1="29" x2="64" y2="29" />
   <line x1="39" y1="29" x2="64" y2="29" />
@@ -9366,11 +8844,6 @@ Attributes:
   <line x1="39" y1="29" x2="65" y2="29" />
   <line x1="39" y1="29" x2="65" y2="29" />
   <line x1="39" y1="29" x2="65" y2="29" />
-  <line x1="39" y1="29" x2="65" y2="29" />
-  <line x1="39" y1="29" x2="65" y2="29" />
-  <line x1="40" y1="30" x2="65" y2="30" />
-  <line x1="40" y1="30" x2="65" y2="30" />
-  <line x1="40" y1="30" x2="65" y2="30" />
   <line x1="40" y1="30" x2="65" y2="30" />
   <line x1="40" y1="30" x2="65" y2="30" />
   <line x1="40" y1="30" x2="65" y2="30" />
@@ -9454,12 +8927,6 @@ Attributes:
   <line x1="40" y1="30" x2="66" y2="30" />
   <line x1="40" y1="30" x2="66" y2="30" />
   <line x1="40" y1="30" x2="66" y2="30" />
-  <line x1="40" y1="30" x2="66" y2="30" />
-  <line x1="40" y1="30" x2="66" y2="30" />
-  <line x1="41" y1="31" x2="66" y2="31" />
-  <line x1="41" y1="31" x2="66" y2="31" />
-  <line x1="41" y1="31" x2="66" y2="31" />
-  <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="66" y2="31" />
@@ -9542,11 +9009,6 @@ Attributes:
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
-  <line x1="41" y1="31" x2="67" y2="31" />
-  <line x1="41" y1="31" x2="67" y2="31" />
-  <line x1="42" y1="32" x2="67" y2="32" />
-  <line x1="42" y1="32" x2="67" y2="32" />
-  <line x1="42" y1="32" x2="67" y2="32" />
   <line x1="42" y1="32" x2="67" y2="32" />
   <line x1="42" y1="32" x2="67" y2="32" />
   <line x1="42" y1="32" x2="67" y2="32" />
@@ -9630,11 +9092,6 @@ Attributes:
   <line x1="42" y1="32" x2="68" y2="32" />
   <line x1="42" y1="32" x2="68" y2="32" />
   <line x1="42" y1="32" x2="68" y2="32" />
-  <line x1="42" y1="32" x2="68" y2="32" />
-  <line x1="42" y1="32" x2="68" y2="32" />
-  <line x1="43" y1="33" x2="68" y2="33" />
-  <line x1="43" y1="33" x2="68" y2="33" />
-  <line x1="43" y1="33" x2="68" y2="33" />
   <line x1="43" y1="33" x2="68" y2="33" />
   <line x1="43" y1="33" x2="68" y2="33" />
   <line x1="43" y1="33" x2="68" y2="33" />
@@ -9718,11 +9175,6 @@ Attributes:
   <line x1="43" y1="33" x2="69" y2="33" />
   <line x1="43" y1="33" x2="69" y2="33" />
   <line x1="43" y1="33" x2="69" y2="33" />
-  <line x1="43" y1="33" x2="69" y2="33" />
-  <line x1="43" y1="33" x2="69" y2="33" />
-  <line x1="44" y1="34" x2="69" y2="34" />
-  <line x1="44" y1="34" x2="69" y2="34" />
-  <line x1="44" y1="34" x2="69" y2="34" />
   <line x1="44" y1="34" x2="69" y2="34" />
   <line x1="44" y1="34" x2="69" y2="34" />
   <line x1="44" y1="34" x2="69" y2="34" />
@@ -9806,12 +9258,6 @@ Attributes:
   <line x1="44" y1="34" x2="70" y2="34" />
   <line x1="44" y1="34" x2="70" y2="34" />
   <line x1="44" y1="34" x2="70" y2="34" />
-  <line x1="44" y1="34" x2="70" y2="34" />
-  <line x1="44" y1="34" x2="70" y2="34" />
-  <line x1="45" y1="35" x2="70" y2="35" />
-  <line x1="45" y1="35" x2="70" y2="35" />
-  <line x1="45" y1="35" x2="70" y2="35" />
-  <line x1="45" y1="35" x2="70" y2="35" />
   <line x1="45" y1="35" x2="70" y2="35" />
   <line x1="45" y1="35" x2="70" y2="35" />
   <line x1="45" y1="35" x2="70" y2="35" />
@@ -9894,11 +9340,6 @@ Attributes:
   <line x1="45" y1="35" x2="71" y2="35" />
   <line x1="45" y1="35" x2="71" y2="35" />
   <line x1="45" y1="35" x2="71" y2="35" />
-  <line x1="45" y1="35" x2="71" y2="35" />
-  <line x1="45" y1="35" x2="71" y2="35" />
-  <line x1="46" y1="36" x2="71" y2="36" />
-  <line x1="46" y1="36" x2="71" y2="36" />
-  <line x1="46" y1="36" x2="71" y2="36" />
   <line x1="46" y1="36" x2="71" y2="36" />
   <line x1="46" y1="36" x2="71" y2="36" />
   <line x1="46" y1="36" x2="71" y2="36" />
@@ -9982,11 +9423,6 @@ Attributes:
   <line x1="46" y1="36" x2="72" y2="36" />
   <line x1="46" y1="36" x2="72" y2="36" />
   <line x1="46" y1="36" x2="72" y2="36" />
-  <line x1="46" y1="36" x2="72" y2="36" />
-  <line x1="46" y1="36" x2="72" y2="36" />
-  <line x1="47" y1="37" x2="72" y2="37" />
-  <line x1="47" y1="37" x2="72" y2="37" />
-  <line x1="47" y1="37" x2="72" y2="37" />
   <line x1="47" y1="37" x2="72" y2="37" />
   <line x1="47" y1="37" x2="72" y2="37" />
   <line x1="47" y1="37" x2="72" y2="37" />
@@ -10070,11 +9506,6 @@ Attributes:
   <line x1="47" y1="37" x2="73" y2="37" />
   <line x1="47" y1="37" x2="73" y2="37" />
   <line x1="47" y1="37" x2="73" y2="37" />
-  <line x1="47" y1="37" x2="73" y2="37" />
-  <line x1="47" y1="37" x2="73" y2="37" />
-  <line x1="48" y1="38" x2="73" y2="38" />
-  <line x1="48" y1="38" x2="73" y2="38" />
-  <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="73" y2="38" />
@@ -10158,12 +9589,6 @@ Attributes:
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
-  <line x1="48" y1="38" x2="74" y2="38" />
-  <line x1="48" y1="38" x2="74" y2="38" />
-  <line x1="49" y1="39" x2="74" y2="39" />
-  <line x1="49" y1="39" x2="74" y2="39" />
-  <line x1="49" y1="39" x2="74" y2="39" />
-  <line x1="49" y1="39" x2="74" y2="39" />
   <line x1="49" y1="39" x2="74" y2="39" />
   <line x1="49" y1="39" x2="74" y2="39" />
   <line x1="49" y1="39" x2="74" y2="39" />
@@ -10246,11 +9671,6 @@ Attributes:
   <line x1="49" y1="39" x2="75" y2="39" />
   <line x1="49" y1="39" x2="75" y2="39" />
   <line x1="49" y1="39" x2="75" y2="39" />
-  <line x1="49" y1="39" x2="75" y2="39" />
-  <line x1="49" y1="39" x2="75" y2="39" />
-  <line x1="50" y1="40" x2="75" y2="40" />
-  <line x1="50" y1="40" x2="75" y2="40" />
-  <line x1="50" y1="40" x2="75" y2="40" />
   <line x1="50" y1="40" x2="75" y2="40" />
   <line x1="50" y1="40" x2="75" y2="40" />
   <line x1="50" y1="40" x2="75" y2="40" />
@@ -10334,11 +9754,6 @@ Attributes:
   <line x1="50" y1="40" x2="76" y2="40" />
   <line x1="50" y1="40" x2="76" y2="40" />
   <line x1="50" y1="40" x2="76" y2="40" />
-  <line x1="50" y1="40" x2="76" y2="40" />
-  <line x1="50" y1="40" x2="76" y2="40" />
-  <line x1="51" y1="41" x2="76" y2="41" />
-  <line x1="51" y1="41" x2="76" y2="41" />
-  <line x1="51" y1="41" x2="76" y2="41" />
   <line x1="51" y1="41" x2="76" y2="41" />
   <line x1="51" y1="41" x2="76" y2="41" />
   <line x1="51" y1="41" x2="76" y2="41" />
@@ -10422,12 +9837,6 @@ Attributes:
   <line x1="51" y1="41" x2="77" y2="41" />
   <line x1="51" y1="41" x2="77" y2="41" />
   <line x1="51" y1="41" x2="77" y2="41" />
-  <line x1="51" y1="41" x2="77" y2="41" />
-  <line x1="51" y1="41" x2="77" y2="41" />
-  <line x1="52" y1="42" x2="77" y2="42" />
-  <line x1="52" y1="42" x2="77" y2="42" />
-  <line x1="52" y1="42" x2="77" y2="42" />
-  <line x1="52" y1="42" x2="77" y2="42" />
   <line x1="52" y1="42" x2="77" y2="42" />
   <line x1="52" y1="42" x2="77" y2="42" />
   <line x1="52" y1="42" x2="77" y2="42" />
@@ -10511,10 +9920,6 @@ Attributes:
   <line x1="52" y1="42" x2="78" y2="42" />
   <line x1="52" y1="42" x2="78" y2="42" />
   <line x1="52" y1="42" x2="78" y2="42" />
-  <line x1="52" y1="42" x2="78" y2="42" />
-  <line x1="53" y1="43" x2="78" y2="43" />
-  <line x1="53" y1="43" x2="78" y2="43" />
-  <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="78" y2="43" />
@@ -10597,11 +10002,6 @@ Attributes:
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
-  <line x1="53" y1="43" x2="79" y2="43" />
-  <line x1="53" y1="43" x2="79" y2="43" />
-  <line x1="53" y1="43" x2="79" y2="43" />
-  <line x1="54" y1="44" x2="79" y2="44" />
-  <line x1="54" y1="44" x2="79" y2="44" />
   <line x1="54" y1="44" x2="79" y2="44" />
   <line x1="54" y1="44" x2="79" y2="44" />
   <line x1="54" y1="44" x2="79" y2="44" />
@@ -10685,11 +10085,6 @@ Attributes:
   <line x1="54" y1="44" x2="80" y2="44" />
   <line x1="54" y1="44" x2="80" y2="44" />
   <line x1="54" y1="44" x2="80" y2="44" />
-  <line x1="54" y1="44" x2="80" y2="44" />
-  <line x1="54" y1="44" x2="80" y2="44" />
-  <line x1="54" y1="44" x2="80" y2="44" />
-  <line x1="55" y1="45" x2="80" y2="45" />
-  <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="80" y2="45" />
@@ -10773,12 +10168,6 @@ Attributes:
   <line x1="55" y1="45" x2="81" y2="45" />
   <line x1="55" y1="45" x2="81" y2="45" />
   <line x1="55" y1="45" x2="81" y2="45" />
-  <line x1="55" y1="45" x2="81" y2="45" />
-  <line x1="55" y1="45" x2="81" y2="45" />
-  <line x1="55" y1="45" x2="81" y2="45" />
-  <line x1="56" y1="46" x2="81" y2="46" />
-  <line x1="56" y1="46" x2="81" y2="46" />
-  <line x1="56" y1="46" x2="81" y2="46" />
   <line x1="56" y1="46" x2="81" y2="46" />
   <line x1="56" y1="46" x2="81" y2="46" />
   <line x1="56" y1="46" x2="81" y2="46" />
@@ -10862,11 +10251,6 @@ Attributes:
   <line x1="56" y1="46" x2="82" y2="46" />
   <line x1="56" y1="46" x2="82" y2="46" />
   <line x1="56" y1="46" x2="82" y2="46" />
-  <line x1="56" y1="46" x2="82" y2="46" />
-  <line x1="56" y1="46" x2="82" y2="46" />
-  <line x1="57" y1="47" x2="82" y2="47" />
-  <line x1="57" y1="47" x2="82" y2="47" />
-  <line x1="57" y1="47" x2="82" y2="47" />
   <line x1="57" y1="47" x2="82" y2="47" />
   <line x1="57" y1="47" x2="82" y2="47" />
   <line x1="57" y1="47" x2="82" y2="47" />
@@ -10949,11 +10333,6 @@ Attributes:
   <line x1="57" y1="47" x2="83" y2="47" />
   <line x1="57" y1="47" x2="83" y2="47" />
   <line x1="57" y1="47" x2="83" y2="47" />
-  <line x1="57" y1="47" x2="83" y2="47" />
-  <line x1="57" y1="47" x2="83" y2="47" />
-  <line x1="57" y1="47" x2="83" y2="47" />
-  <line x1="58" y1="48" x2="83" y2="48" />
-  <line x1="58" y1="48" x2="83" y2="48" />
   <line x1="58" y1="48" x2="83" y2="48" />
   <line x1="58" y1="48" x2="83" y2="48" />
   <line x1="58" y1="48" x2="83" y2="48" />
@@ -11037,11 +10416,6 @@ Attributes:
   <line x1="58" y1="48" x2="84" y2="48" />
   <line x1="58" y1="48" x2="84" y2="48" />
   <line x1="58" y1="48" x2="84" y2="48" />
-  <line x1="58" y1="48" x2="84" y2="48" />
-  <line x1="58" y1="48" x2="84" y2="48" />
-  <line x1="58" y1="48" x2="84" y2="48" />
-  <line x1="59" y1="49" x2="84" y2="49" />
-  <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
@@ -11125,12 +10499,6 @@ Attributes:
   <line x1="59" y1="49" x2="85" y2="49" />
   <line x1="59" y1="49" x2="85" y2="49" />
   <line x1="59" y1="49" x2="85" y2="49" />
-  <line x1="59" y1="49" x2="85" y2="49" />
-  <line x1="59" y1="49" x2="85" y2="49" />
-  <line x1="59" y1="49" x2="85" y2="49" />
-  <line x1="60" y1="50" x2="85" y2="50" />
-  <line x1="60" y1="50" x2="85" y2="50" />
-  <line x1="60" y1="50" x2="85" y2="50" />
   <line x1="60" y1="50" x2="85" y2="50" />
   <line x1="60" y1="50" x2="85" y2="50" />
   <line x1="60" y1="50" x2="85" y2="50" />
@@ -11214,8 +10582,6 @@ Attributes:
   <line x1="60" y1="50" x2="86" y2="50" />
   <line x1="60" y1="50" x2="86" y2="50" />
   <line x1="60" y1="50" x2="86" y2="50" />
-  <line x1="60" y1="50" x2="86" y2="50" />
-  <line x1="60" y1="50" x2="86" y2="50" />
   <line x1="61" y1="51" x2="86" y2="51" />
   <line x1="61" y1="51" x2="86" y2="51" />
   <line x1="61" y1="51" x2="86" y2="51" />
@@ -11264,11 +10630,6 @@ Attributes:
   <line x1="61" y1="51" x2="86" y2="51" />
   <line x1="61" y1="51" x2="86" y2="51" />
   <line x1="61" y1="51" x2="86" y2="51" />
-  <line x1="61" y1="51" x2="86" y2="51" />
-  <line x1="61" y1="51" x2="86" y2="51" />
-  <line x1="61" y1="51" x2="86" y2="51" />
-  <line x1="61" y1="51" x2="87" y2="51" />
-  <line x1="61" y1="51" x2="87" y2="51" />
   <line x1="61" y1="51" x2="87" y2="51" />
   <line x1="61" y1="51" x2="87" y2="51" />
   <line x1="61" y1="51" x2="87" y2="51" />
@@ -11352,9 +10713,6 @@ Attributes:
   <line x1="62" y1="52" x2="87" y2="52" />
   <line x1="62" y1="52" x2="87" y2="52" />
   <line x1="62" y1="52" x2="87" y2="52" />
-  <line x1="62" y1="52" x2="87" y2="52" />
-  <line x1="62" y1="52" x2="87" y2="52" />
-  <line x1="62" y1="52" x2="87" y2="52" />
   <line x1="62" y1="52" x2="88" y2="52" />
   <line x1="62" y1="52" x2="88" y2="52" />
   <line x1="62" y1="52" x2="88" y2="52" />
@@ -11389,11 +10747,6 @@ Attributes:
   <line x1="62" y1="52" x2="88" y2="52" />
   <line x1="62" y1="52" x2="88" y2="52" />
   <line x1="62" y1="52" x2="88" y2="52" />
-  <line x1="62" y1="52" x2="88" y2="52" />
-  <line x1="62" y1="52" x2="88" y2="52" />
-  <line x1="63" y1="53" x2="88" y2="53" />
-  <line x1="63" y1="53" x2="88" y2="53" />
-  <line x1="63" y1="53" x2="88" y2="53" />
   <line x1="63" y1="53" x2="88" y2="53" />
   <line x1="63" y1="53" x2="88" y2="53" />
   <line x1="63" y1="53" x2="88" y2="53" />
@@ -11477,12 +10830,6 @@ Attributes:
   <line x1="63" y1="53" x2="89" y2="53" />
   <line x1="63" y1="53" x2="89" y2="53" />
   <line x1="63" y1="53" x2="89" y2="53" />
-  <line x1="63" y1="53" x2="89" y2="53" />
-  <line x1="63" y1="53" x2="89" y2="53" />
-  <line x1="64" y1="54" x2="89" y2="54" />
-  <line x1="64" y1="54" x2="89" y2="54" />
-  <line x1="64" y1="54" x2="89" y2="54" />
-  <line x1="64" y1="54" x2="89" y2="54" />
   <line x1="64" y1="54" x2="89" y2="54" />
   <line x1="64" y1="54" x2="89" y2="54" />
   <line x1="64" y1="54" x2="89" y2="54" />
@@ -11566,11 +10913,6 @@ Attributes:
   <line x1="64" y1="54" x2="90" y2="54" />
   <line x1="64" y1="54" x2="90" y2="54" />
   <line x1="64" y1="54" x2="90" y2="54" />
-  <line x1="64" y1="54" x2="90" y2="54" />
-  <line x1="65" y1="55" x2="90" y2="55" />
-  <line x1="65" y1="55" x2="90" y2="55" />
-  <line x1="65" y1="55" x2="90" y2="55" />
-  <line x1="65" y1="55" x2="90" y2="55" />
   <line x1="65" y1="55" x2="90" y2="55" />
   <line x1="65" y1="55" x2="90" y2="55" />
   <line x1="65" y1="55" x2="90" y2="55" />
@@ -11653,11 +10995,6 @@ Attributes:
   <line x1="65" y1="55" x2="91" y2="55" />
   <line x1="65" y1="55" x2="91" y2="55" />
   <line x1="65" y1="55" x2="91" y2="55" />
-  <line x1="65" y1="55" x2="91" y2="55" />
-  <line x1="65" y1="55" x2="91" y2="55" />
-  <line x1="66" y1="56" x2="91" y2="56" />
-  <line x1="66" y1="56" x2="91" y2="56" />
-  <line x1="66" y1="56" x2="91" y2="56" />
   <line x1="66" y1="56" x2="91" y2="56" />
   <line x1="66" y1="56" x2="91" y2="56" />
   <line x1="66" y1="56" x2="91" y2="56" />
@@ -11741,11 +11078,6 @@ Attributes:
   <line x1="66" y1="56" x2="92" y2="56" />
   <line x1="66" y1="56" x2="92" y2="56" />
   <line x1="66" y1="56" x2="92" y2="56" />
-  <line x1="66" y1="56" x2="92" y2="56" />
-  <line x1="66" y1="56" x2="92" y2="56" />
-  <line x1="67" y1="57" x2="92" y2="57" />
-  <line x1="67" y1="57" x2="92" y2="57" />
-  <line x1="67" y1="57" x2="92" y2="57" />
   <line x1="67" y1="57" x2="92" y2="57" />
   <line x1="67" y1="57" x2="92" y2="57" />
   <line x1="67" y1="57" x2="92" y2="57" />
@@ -11829,12 +11161,6 @@ Attributes:
   <line x1="67" y1="57" x2="93" y2="57" />
   <line x1="67" y1="57" x2="93" y2="57" />
   <line x1="67" y1="57" x2="93" y2="57" />
-  <line x1="67" y1="57" x2="93" y2="57" />
-  <line x1="67" y1="57" x2="93" y2="57" />
-  <line x1="68" y1="58" x2="93" y2="58" />
-  <line x1="68" y1="58" x2="93" y2="58" />
-  <line x1="68" y1="58" x2="93" y2="58" />
-  <line x1="68" y1="58" x2="93" y2="58" />
   <line x1="68" y1="58" x2="93" y2="58" />
   <line x1="68" y1="58" x2="93" y2="58" />
   <line x1="68" y1="58" x2="93" y2="58" />
@@ -11918,11 +11244,6 @@ Attributes:
   <line x1="68" y1="58" x2="94" y2="58" />
   <line x1="68" y1="58" x2="94" y2="58" />
   <line x1="68" y1="58" x2="94" y2="58" />
-  <line x1="68" y1="58" x2="94" y2="58" />
-  <line x1="69" y1="59" x2="94" y2="59" />
-  <line x1="69" y1="59" x2="94" y2="59" />
-  <line x1="69" y1="59" x2="94" y2="59" />
-  <line x1="69" y1="59" x2="94" y2="59" />
   <line x1="69" y1="59" x2="94" y2="59" />
   <line x1="69" y1="59" x2="94" y2="59" />
   <line x1="69" y1="59" x2="94" y2="59" />
@@ -12005,11 +11326,6 @@ Attributes:
   <line x1="69" y1="59" x2="95" y2="59" />
   <line x1="69" y1="59" x2="95" y2="59" />
   <line x1="69" y1="59" x2="95" y2="59" />
-  <line x1="69" y1="59" x2="95" y2="59" />
-  <line x1="69" y1="59" x2="95" y2="59" />
-  <line x1="70" y1="60" x2="95" y2="60" />
-  <line x1="70" y1="60" x2="95" y2="60" />
-  <line x1="70" y1="60" x2="95" y2="60" />
   <line x1="70" y1="60" x2="95" y2="60" />
   <line x1="70" y1="60" x2="95" y2="60" />
   <line x1="70" y1="60" x2="95" y2="60" />
@@ -12093,11 +11409,6 @@ Attributes:
   <line x1="70" y1="60" x2="96" y2="60" />
   <line x1="70" y1="60" x2="96" y2="60" />
   <line x1="70" y1="60" x2="96" y2="60" />
-  <line x1="70" y1="60" x2="96" y2="60" />
-  <line x1="70" y1="60" x2="96" y2="60" />
-  <line x1="71" y1="61" x2="96" y2="61" />
-  <line x1="71" y1="61" x2="96" y2="61" />
-  <line x1="71" y1="61" x2="96" y2="61" />
   <line x1="71" y1="61" x2="96" y2="61" />
   <line x1="71" y1="61" x2="96" y2="61" />
   <line x1="71" y1="61" x2="96" y2="61" />
@@ -12181,12 +11492,6 @@ Attributes:
   <line x1="71" y1="61" x2="97" y2="61" />
   <line x1="71" y1="61" x2="97" y2="61" />
   <line x1="71" y1="61" x2="97" y2="61" />
-  <line x1="71" y1="61" x2="97" y2="61" />
-  <line x1="71" y1="61" x2="97" y2="61" />
-  <line x1="72" y1="62" x2="97" y2="62" />
-  <line x1="72" y1="62" x2="97" y2="62" />
-  <line x1="72" y1="62" x2="97" y2="62" />
-  <line x1="72" y1="62" x2="97" y2="62" />
   <line x1="72" y1="62" x2="97" y2="62" />
   <line x1="72" y1="62" x2="97" y2="62" />
   <line x1="72" y1="62" x2="97" y2="62" />
@@ -12270,11 +11575,6 @@ Attributes:
   <line x1="72" y1="62" x2="98" y2="62" />
   <line x1="72" y1="62" x2="98" y2="62" />
   <line x1="72" y1="62" x2="98" y2="62" />
-  <line x1="72" y1="62" x2="98" y2="62" />
-  <line x1="73" y1="63" x2="98" y2="63" />
-  <line x1="73" y1="63" x2="98" y2="63" />
-  <line x1="73" y1="63" x2="98" y2="63" />
-  <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="98" y2="63" />
@@ -12357,11 +11657,6 @@ Attributes:
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
-  <line x1="73" y1="63" x2="99" y2="63" />
-  <line x1="73" y1="63" x2="99" y2="63" />
-  <line x1="74" y1="64" x2="99" y2="64" />
-  <line x1="74" y1="64" x2="99" y2="64" />
-  <line x1="74" y1="64" x2="99" y2="64" />
   <line x1="74" y1="64" x2="99" y2="64" />
   <line x1="74" y1="64" x2="99" y2="64" />
   <line x1="74" y1="64" x2="99" y2="64" />
@@ -12445,11 +11740,6 @@ Attributes:
   <line x1="74" y1="64" x2="100" y2="64" />
   <line x1="74" y1="64" x2="100" y2="64" />
   <line x1="74" y1="64" x2="100" y2="64" />
-  <line x1="74" y1="64" x2="100" y2="64" />
-  <line x1="74" y1="64" x2="100" y2="64" />
-  <line x1="75" y1="65" x2="100" y2="65" />
-  <line x1="75" y1="65" x2="100" y2="65" />
-  <line x1="75" y1="65" x2="100" y2="65" />
   <line x1="75" y1="65" x2="100" y2="65" />
   <line x1="75" y1="65" x2="100" y2="65" />
   <line x1="75" y1="65" x2="100" y2="65" />
@@ -12533,12 +11823,6 @@ Attributes:
   <line x1="75" y1="65" x2="101" y2="65" />
   <line x1="75" y1="65" x2="101" y2="65" />
   <line x1="75" y1="65" x2="101" y2="65" />
-  <line x1="75" y1="65" x2="101" y2="65" />
-  <line x1="75" y1="65" x2="101" y2="65" />
-  <line x1="76" y1="66" x2="101" y2="66" />
-  <line x1="76" y1="66" x2="101" y2="66" />
-  <line x1="76" y1="66" x2="101" y2="66" />
-  <line x1="76" y1="66" x2="101" y2="66" />
   <line x1="76" y1="66" x2="101" y2="66" />
   <line x1="76" y1="66" x2="101" y2="66" />
   <line x1="76" y1="66" x2="101" y2="66" />
@@ -12622,11 +11906,6 @@ Attributes:
   <line x1="76" y1="66" x2="102" y2="66" />
   <line x1="76" y1="66" x2="102" y2="66" />
   <line x1="76" y1="66" x2="102" y2="66" />
-  <line x1="76" y1="66" x2="102" y2="66" />
-  <line x1="77" y1="67" x2="102" y2="67" />
-  <line x1="77" y1="67" x2="102" y2="67" />
-  <line x1="77" y1="67" x2="102" y2="67" />
-  <line x1="77" y1="67" x2="102" y2="67" />
   <line x1="77" y1="67" x2="102" y2="67" />
   <line x1="77" y1="67" x2="102" y2="67" />
   <line x1="77" y1="67" x2="102" y2="67" />
@@ -12709,11 +11988,6 @@ Attributes:
   <line x1="77" y1="67" x2="103" y2="67" />
   <line x1="77" y1="67" x2="103" y2="67" />
   <line x1="77" y1="67" x2="103" y2="67" />
-  <line x1="77" y1="67" x2="103" y2="67" />
-  <line x1="77" y1="67" x2="103" y2="67" />
-  <line x1="78" y1="68" x2="103" y2="68" />
-  <line x1="78" y1="68" x2="103" y2="68" />
-  <line x1="78" y1="68" x2="103" y2="68" />
   <line x1="78" y1="68" x2="103" y2="68" />
   <line x1="78" y1="68" x2="103" y2="68" />
   <line x1="78" y1="68" x2="103" y2="68" />
@@ -12797,10 +12071,6 @@ Attributes:
   <line x1="78" y1="68" x2="104" y2="68" />
   <line x1="78" y1="68" x2="104" y2="68" />
   <line x1="78" y1="68" x2="104" y2="68" />
-  <line x1="78" y1="68" x2="104" y2="68" />
-  <line x1="78" y1="68" x2="104" y2="68" />
-  <line x1="79" y1="69" x2="104" y2="69" />
-  <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="104" y2="69" />
@@ -12884,12 +12154,6 @@ Attributes:
   <line x1="79" y1="69" x2="105" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
-  <line x1="79" y1="69" x2="105" y2="69" />
-  <line x1="79" y1="69" x2="105" y2="69" />
-  <line x1="79" y1="69" x2="105" y2="69" />
-  <line x1="80" y1="70" x2="105" y2="70" />
-  <line x1="80" y1="70" x2="105" y2="70" />
-  <line x1="80" y1="70" x2="105" y2="70" />
   <line x1="80" y1="70" x2="105" y2="70" />
   <line x1="80" y1="70" x2="105" y2="70" />
   <line x1="80" y1="70" x2="105" y2="70" />
@@ -12961,11 +12225,11 @@ Attributes:
   <!-- Text -->
   <text x="93.294544" y="116.000852" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
   <text x="126.000852" y="83.294544" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,126.000852,83.294544)">181</text>
-  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">279405</text>
+  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">186912</text>
 </svg>
 </td>
 </tr>
-</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-84a2c2f1-1856-4eb8-9147-7610d9be0d72' class='xr-section-summary-in' type='checkbox'  checked><label for='section-84a2c2f1-1856-4eb8-9147-7610d9be0d72' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/07/14 07:17:37</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-11a0e266-bc19-444a-bae1-db0e086cc4a3' class='xr-section-summary-in' type='checkbox'  checked><label for='section-11a0e266-bc19-444a-bae1-db0e086cc4a3' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/03/25 21:08:04</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
     
 
 

--- a/ua_200_EMC-GEFS_.anoms.daily.e10.nc.html
+++ b/ua_200_EMC-GEFS_.anoms.daily.e10.nc.html
@@ -1,0 +1,2338 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Anomalies</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Anomalies</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_anoms>subx_hindcast_ua200_daily_anoms</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_anoms_emc-gefs>subx_hindcast_ua200_daily_anoms_emc-gefs</a></li>
+
+
+            <li class="active">SubX Anomalies</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_EMC-GEFS_anoms.daily.e10.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Anomalies</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/anoms/EMC-GEFS</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_EMC-GEFS_anoms.daily.e10.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-07-13</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 31045)
+Coordinates:
+  * lat      (lat) float32 90.0 89.0 88.0 87.0 86.0 ... -87.0 -88.0 -89.0 -90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 30.5 31.5 32.5 33.5 34.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(35, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Anomalies
+    long_title:    SubX Anomalies
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/03/26 19:24:49
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-e5685855-68e4-4a36-a310-61b98124f980' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-e5685855-68e4-4a36-a310-61b98124f980' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 31045</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-49bf1a7b-80ef-40d1-b04a-fd99ec2a0d5b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-49bf1a7b-80ef-40d1-b04a-fd99ec2a0d5b' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>90.0 89.0 88.0 ... -89.0 -90.0</div><input id='attrs-dc6c54fd-0a04-4a62-a783-7a530d771d9c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dc6c54fd-0a04-4a62-a783-7a530d771d9c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-75e7ee9a-deb5-48e7-a41a-f42d53b1d134' class='xr-var-data-in' type='checkbox'><label for='data-75e7ee9a-deb5-48e7-a41a-f42d53b1d134' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([ 90.,  89.,  88.,  87.,  86.,  85.,  84.,  83.,  82.,  81.,  80.,  79.,
+        78.,  77.,  76.,  75.,  74.,  73.,  72.,  71.,  70.,  69.,  68.,  67.,
+        66.,  65.,  64.,  63.,  62.,  61.,  60.,  59.,  58.,  57.,  56.,  55.,
+        54.,  53.,  52.,  51.,  50.,  49.,  48.,  47.,  46.,  45.,  44.,  43.,
+        42.,  41.,  40.,  39.,  38.,  37.,  36.,  35.,  34.,  33.,  32.,  31.,
+        30.,  29.,  28.,  27.,  26.,  25.,  24.,  23.,  22.,  21.,  20.,  19.,
+        18.,  17.,  16.,  15.,  14.,  13.,  12.,  11.,  10.,   9.,   8.,   7.,
+         6.,   5.,   4.,   3.,   2.,   1.,   0.,  -1.,  -2.,  -3.,  -4.,  -5.,
+        -6.,  -7.,  -8.,  -9., -10., -11., -12., -13., -14., -15., -16., -17.,
+       -18., -19., -20., -21., -22., -23., -24., -25., -26., -27., -28., -29.,
+       -30., -31., -32., -33., -34., -35., -36., -37., -38., -39., -40., -41.,
+       -42., -43., -44., -45., -46., -47., -48., -49., -50., -51., -52., -53.,
+       -54., -55., -56., -57., -58., -59., -60., -61., -62., -63., -64., -65.,
+       -66., -67., -68., -69., -70., -71., -72., -73., -74., -75., -76., -77.,
+       -78., -79., -80., -81., -82., -83., -84., -85., -86., -87., -88., -89.,
+       -90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-8c08b53e-fb9e-44ba-9c0b-2770af3fda7e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8c08b53e-fb9e-44ba-9c0b-2770af3fda7e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fb3ca557-73a4-435e-bcdc-c3da72c40c70' class='xr-var-data-in' type='checkbox'><label for='data-fb3ca557-73a4-435e-bcdc-c3da72c40c70' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 32.5 33.5 34.5</div><input id='attrs-0f909e2f-f202-41f3-ac4b-2cc9d65a7890' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0f909e2f-f202-41f3-ac4b-2cc9d65a7890' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d37882f2-9ee8-40f1-a8e3-e1454f012e5f' class='xr-var-data-in' type='checkbox'><label for='data-d37882f2-9ee8-40f1-a8e3-e1454f012e5f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 32.5, 33.5, 34.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-626b7b7c-f1d7-40fe-a7a1-c96ff4742ef8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-626b7b7c-f1d7-40fe-a7a1-c96ff4742ef8' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(35, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-35c54586-c97e-4d46-a06b-ce4c57668d66' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-35c54586-c97e-4d46-a06b-ce4c57668d66' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-96c18280-f0ed-4c42-a06f-cfcdedc39cd0' class='xr-var-data-in' type='checkbox'><label for='data-96c18280-f0ed-4c42-a06f-cfcdedc39cd0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m/s</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 8.09 GB </td> <td> 9.12 MB </td></tr>
+    <tr><th> Shape </th><td> (31045, 181, 360) </td> <td> (35, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 2661 Tasks </td><td> 887 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="156" height="146" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="25" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="25" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,96.000852 10.000000,25.412617" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="36" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="36" y1="0" x2="106" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 36.135606,0.000000 106.723841,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="106" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="96" x2="106" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+  <line x1="106" y1="70" x2="106" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 106.723841,70.588235 106.723841,96.000852 80.588235,96.000852" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="93.656038" y="116.000852" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="126.723841" y="83.294544" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,126.723841,83.294544)">181</text>
+  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">31045</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-e3467eb6-cf21-449b-8f14-b0c3d0aa5be8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e3467eb6-cf21-449b-8f14-b0c3d0aa5be8' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/03/26 19:24:49</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_200_ESRL-FIMr1p1_.anoms.daily.e2.nc.html
+++ b/ua_200_ESRL-FIMr1p1_.anoms.daily.e2.nc.html
@@ -1,0 +1,2338 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Anomalies</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Anomalies</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_anoms>subx_hindcast_ua200_daily_anoms</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_anoms_esrl-fimr1p1>subx_hindcast_ua200_daily_anoms_esrl-fimr1p1</a></li>
+
+
+            <li class="active">SubX Anomalies</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_ESRL-FIMr1p1_anoms.daily.e2.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Anomalies</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/anoms/ESRL-FIMr1p1</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_ESRL-FIMr1p1_anoms.daily.e2.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-07-13</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 28384)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 27.5 28.5 29.5 30.5 31.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Anomalies
+    long_title:    SubX Anomalies
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/03/25 04:47:42
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a0b0e1e7-ecba-4ed9-8578-08554fab39bd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a0b0e1e7-ecba-4ed9-8578-08554fab39bd' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 28384</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b92c822c-2e91-4971-969a-7c031a928aea' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b92c822c-2e91-4971-969a-7c031a928aea' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-1aba1ddf-8a24-4a7f-abfe-2e46bce7ee3c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1aba1ddf-8a24-4a7f-abfe-2e46bce7ee3c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2153ec48-fac7-430b-9e66-15de138dc324' class='xr-var-data-in' type='checkbox'><label for='data-2153ec48-fac7-430b-9e66-15de138dc324' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-743e476c-357e-475f-b473-c0486bca5d8e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-743e476c-357e-475f-b473-c0486bca5d8e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-aef3673a-44b0-497e-a24f-6c4d2c12b21f' class='xr-var-data-in' type='checkbox'><label for='data-aef3673a-44b0-497e-a24f-6c4d2c12b21f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 29.5 30.5 31.5</div><input id='attrs-12208a96-452c-419d-b6b3-84a3d0981cbd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-12208a96-452c-419d-b6b3-84a3d0981cbd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13ae933a-263a-49a0-ae12-583603887507' class='xr-var-data-in' type='checkbox'><label for='data-13ae933a-263a-49a0-ae12-583603887507' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 29.5, 30.5, 31.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-39aef0e0-c593-42d0-9b02-45163f8936f5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-39aef0e0-c593-42d0-9b02-45163f8936f5' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-8aa1fb04-673b-42cb-8f89-752383de3e81' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8aa1fb04-673b-42cb-8f89-752383de3e81' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-927a1408-bf4c-4d8a-8c39-4196071c702b' class='xr-var-data-in' type='checkbox'><label for='data-927a1408-bf4c-4d8a-8c39-4196071c702b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m s-1</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 7.40 GB </td> <td> 8.34 MB </td></tr>
+    <tr><th> Shape </th><td> (28384, 181, 360) </td> <td> (32, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 2661 Tasks </td><td> 887 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="157" height="146" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="25" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="25" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="25" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,96.000852 10.000000,25.412617" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="36" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="36" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="10" y1="0" x2="37" y2="0" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="37" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="11" y1="1" x2="38" y2="1" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="38" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="12" y1="2" x2="39" y2="2" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="39" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="13" y1="3" x2="40" y2="3" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="40" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="14" y1="4" x2="41" y2="4" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="41" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="15" y1="5" x2="42" y2="5" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="42" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="16" y1="6" x2="43" y2="6" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="43" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="17" y1="7" x2="44" y2="7" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="44" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="18" y1="8" x2="45" y2="8" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="45" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="19" y1="9" x2="46" y2="9" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="46" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="20" y1="10" x2="47" y2="10" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="47" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="21" y1="11" x2="48" y2="11" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="48" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="22" y1="12" x2="49" y2="12" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="49" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="23" y1="13" x2="50" y2="13" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="50" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="24" y1="14" x2="51" y2="14" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="51" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="25" y1="15" x2="52" y2="15" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="52" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="26" y1="16" x2="53" y2="16" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="53" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="27" y1="17" x2="54" y2="17" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="28" y1="18" x2="55" y2="18" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="29" y1="19" x2="56" y2="19" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="30" y1="20" x2="57" y2="20" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="31" y1="21" x2="58" y2="21" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="58" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="32" y1="22" x2="59" y2="22" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="33" y1="23" x2="60" y2="23" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="34" y1="24" x2="61" y2="24" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="61" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="35" y1="25" x2="62" y2="25" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="62" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="36" y1="26" x2="63" y2="26" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="63" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="37" y1="27" x2="64" y2="27" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="64" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="38" y1="28" x2="65" y2="28" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="65" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="39" y1="29" x2="66" y2="29" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="66" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="40" y1="30" x2="67" y2="30" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="67" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="41" y1="31" x2="68" y2="31" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="68" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="42" y1="32" x2="69" y2="32" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="69" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="43" y1="33" x2="70" y2="33" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="70" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="44" y1="34" x2="71" y2="34" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="71" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="45" y1="35" x2="72" y2="35" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="72" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="46" y1="36" x2="73" y2="36" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="73" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="47" y1="37" x2="74" y2="37" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="74" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="48" y1="38" x2="75" y2="38" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="75" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="49" y1="39" x2="76" y2="39" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="76" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="50" y1="40" x2="77" y2="40" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="77" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="51" y1="41" x2="78" y2="41" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="78" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="52" y1="42" x2="79" y2="42" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="53" y1="43" x2="80" y2="43" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="80" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="54" y1="44" x2="81" y2="44" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="55" y1="45" x2="82" y2="45" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="56" y1="46" x2="83" y2="46" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="57" y1="47" x2="84" y2="47" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="58" y1="48" x2="85" y2="48" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="59" y1="49" x2="86" y2="49" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="60" y1="50" x2="87" y2="50" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="87" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="61" y1="51" x2="88" y2="51" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="88" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="62" y1="52" x2="89" y2="52" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="89" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="63" y1="53" x2="90" y2="53" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="90" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="64" y1="54" x2="91" y2="54" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="91" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="65" y1="55" x2="92" y2="55" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="92" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="66" y1="56" x2="93" y2="56" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="93" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="67" y1="57" x2="94" y2="57" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="94" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="68" y1="58" x2="95" y2="58" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="95" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="69" y1="59" x2="96" y2="59" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="96" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="70" y1="60" x2="97" y2="60" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="97" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="71" y1="61" x2="98" y2="61" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="98" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="72" y1="62" x2="99" y2="62" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="99" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="73" y1="63" x2="100" y2="63" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="100" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="74" y1="64" x2="101" y2="64" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="101" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="75" y1="65" x2="102" y2="65" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="102" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="76" y1="66" x2="103" y2="66" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="103" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="77" y1="67" x2="104" y2="67" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="104" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="78" y1="68" x2="105" y2="68" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="79" y1="69" x2="106" y2="69" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="106" y2="70" />
+  <line x1="80" y1="70" x2="107" y2="70" />
+  <line x1="80" y1="70" x2="107" y2="70" />
+  <line x1="80" y1="70" x2="107" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="36" y1="0" x2="107" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 36.586658,0.000000 107.174893,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="107" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="96" x2="107" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+  <line x1="107" y1="70" x2="107" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 107.174893,70.588235 107.174893,96.000852 80.588235,96.000852" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="93.881564" y="116.000852" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="127.174893" y="83.294544" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,127.174893,83.294544)">181</text>
+  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">28384</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-7741fe10-ce65-48ba-a96f-888c7f505e6b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7741fe10-ce65-48ba-a96f-888c7f505e6b' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/03/25 04:47:42</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_200_GMAO-GEOS_V2p1_.anoms.daily.e3.nc.html
+++ b/ua_200_GMAO-GEOS_V2p1_.anoms.daily.e3.nc.html
@@ -51,7 +51,7 @@
 
 <li><a href=subx_hindcast_ua200_daily_anoms>subx_hindcast_ua200_daily_anoms</a></li>
 
-<li><a href=subx_hindcast_ua200_daily_anoms_nrl-nesm>subx_hindcast_ua200_daily_anoms_nrl-nesm</a></li>
+<li><a href=subx_hindcast_ua200_daily_anoms_gmao-geos_v2p1>subx_hindcast_ua200_daily_anoms_gmao-geos_v2p1</a></li>
 
 
             <li class="active">SubX Anomalies</li>
@@ -64,7 +64,7 @@
 
         <h3>Load in Python</h3>
         <pre><code class="language-python">from intake import open_catalog<br>
-cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_NRL-NESM_anoms.daily.yaml")
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_GMAO-GEOS_V2p1_anoms.daily.e3.yaml")
 ds=cat.netcdf.read()</code></pre>
 
         <h3>Metadata</h3>
@@ -78,7 +78,7 @@ ds=cat.netcdf.read()</code></pre>
 
             <tr>
                 <td>location</td>
-                <td>/shared/subx/hindcast/ua200/daily/anoms/NRL-NESM</td>
+                <td>/shared/subx/hindcast/ua200/daily/anoms/GMAO-GEOS_V2p1</td>
             </tr>
 
             <tr>
@@ -88,13 +88,13 @@ ds=cat.netcdf.read()</code></pre>
 
             <tr>
                 <td>catalog_dir</td>
-                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_NRL-NESM_anoms.daily.yaml</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_GMAO-GEOS_V2p1_anoms.daily.e3.yaml</td>
             </tr>
     
 
             <tr>
                 <td>last updated </td>
-                <td>2018-07-14</td>
+                <td>2018-07-13</td>
             </tr>
 
 
@@ -461,7 +461,7 @@ dl.xr-attrs {
   fill: currentColor;
 }
 </style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
-Dimensions:  (lat: 181, lon: 360, time: 279405)
+Dimensions:  (lat: 181, lon: 360, time: 279045)
 Coordinates:
   * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
   * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
@@ -474,9 +474,9 @@ Attributes:
     comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
     institution:   IRI
     source:        SubX IRI
-    CreationDate:  2018/07/14 07:17:37
+    CreationDate:  2018/03/27 18:39:04
     CreatedBy:     kpegion
-    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f1be56f8-cf7a-48a7-bf9a-c6ac4d666835' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f1be56f8-cf7a-48a7-bf9a-c6ac4d666835' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 279405</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4333d037-1eb3-4eee-b921-408db2c9f1f8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4333d037-1eb3-4eee-b921-408db2c9f1f8' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-9f5dc649-5581-4c0f-b827-076115a750fc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9f5dc649-5581-4c0f-b827-076115a750fc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bfdcc22f-e7d6-4d5f-a2d0-5aa3747dbac5' class='xr-var-data-in' type='checkbox'><label for='data-bfdcc22f-e7d6-4d5f-a2d0-5aa3747dbac5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c650a8d0-c40c-43eb-92b4-43ebae8e3cb6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c650a8d0-c40c-43eb-92b4-43ebae8e3cb6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 279045</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-8b85fb97-2021-47a8-b672-eadcdedfce68' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8b85fb97-2021-47a8-b672-eadcdedfce68' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-d2b41ca6-4e7c-4d54-89ea-a0cdd3551253' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d2b41ca6-4e7c-4d54-89ea-a0cdd3551253' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9bb02cd3-9d1d-4eb6-8b6f-282c97c491b0' class='xr-var-data-in' type='checkbox'><label for='data-9bb02cd3-9d1d-4eb6-8b6f-282c97c491b0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
        -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
        -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
        -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
@@ -491,7 +491,7 @@ Attributes:
         54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
         66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
         78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
-        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-455b950b-5ee5-44c8-9906-92795e208705' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-455b950b-5ee5-44c8-9906-92795e208705' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-28d6b6a8-5041-4fc6-ad01-db31ecb0b541' class='xr-var-data-in' type='checkbox'><label for='data-28d6b6a8-5041-4fc6-ad01-db31ecb0b541' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-2c10cb96-b5da-484a-ad02-e243f4035bfd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2c10cb96-b5da-484a-ad02-e243f4035bfd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e2282ec9-2cec-4b13-b9a9-6aa3d71d0309' class='xr-var-data-in' type='checkbox'><label for='data-e2282ec9-2cec-4b13-b9a9-6aa3d71d0309' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-61f7f6f4-b0bb-4d6f-9d83-519f7d744f21' class='xr-section-summary-in' type='checkbox'  checked><label for='section-61f7f6f4-b0bb-4d6f-9d83-519f7d744f21' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-ee839924-4e45-4033-86ad-78e4b72d0c1d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee839924-4e45-4033-86ad-78e4b72d0c1d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b9ccdcf8-0938-4685-acad-fae5ef968a9e' class='xr-var-data-in' type='checkbox'><label for='data-b9ccdcf8-0938-4685-acad-fae5ef968a9e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m/s</dd></dl></div><div class='xr-var-data'><table>
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-c00a22fa-3a7d-43ee-a101-db7c9e2e7e58' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c00a22fa-3a7d-43ee-a101-db7c9e2e7e58' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-870b2f38-1204-4970-81ab-245dccbe61a0' class='xr-var-data-in' type='checkbox'><label for='data-870b2f38-1204-4970-81ab-245dccbe61a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-dc6ddeeb-def4-40ad-a9d4-e8505f59f28e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dc6ddeeb-def4-40ad-a9d4-e8505f59f28e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3337a53c-b4aa-4064-b4af-6e49ccb533f7' class='xr-var-data-in' type='checkbox'><label for='data-3337a53c-b4aa-4064-b4af-6e49ccb533f7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d2c103b5-b94f-4bbb-894e-35ef53e6ffea' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d2c103b5-b94f-4bbb-894e-35ef53e6ffea' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-ee3a2cd1-0231-427f-a518-02d6c1b54c74' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee3a2cd1-0231-427f-a518-02d6c1b54c74' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c7948b7b-7587-475e-b5c3-c85fa890a211' class='xr-var-data-in' type='checkbox'><label for='data-c7948b7b-7587-475e-b5c3-c85fa890a211' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m s-1</dd></dl></div><div class='xr-var-data'><table>
 <tr>
 <td>
 <table>
@@ -499,9 +499,9 @@ Attributes:
     <tr><td> </td><th> Array </th><th> Chunk </th></tr>
   </thead>
   <tbody>
-    <tr><th> Bytes </th><td> 72.82 GB </td> <td> 11.73 MB </td></tr>
-    <tr><th> Shape </th><td> (279405, 181, 360) </td> <td> (45, 181, 360) </td></tr>
-    <tr><th> Count </th><td> 18627 Tasks </td><td> 6209 Chunks </td></tr>
+    <tr><th> Bytes </th><td> 72.73 GB </td> <td> 11.73 MB </td></tr>
+    <tr><th> Shape </th><td> (279045, 181, 360) </td> <td> (45, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 18603 Tasks </td><td> 6201 Chunks </td></tr>
     <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
   </tbody>
 </table>
@@ -917,7 +917,6 @@ Attributes:
   <line x1="14" y1="4" x2="14" y2="29" />
   <line x1="14" y1="4" x2="14" y2="29" />
   <line x1="14" y1="4" x2="14" y2="29" />
-  <line x1="14" y1="4" x2="14" y2="29" />
   <line x1="14" y1="4" x2="14" y2="30" />
   <line x1="14" y1="4" x2="14" y2="30" />
   <line x1="14" y1="4" x2="14" y2="30" />
@@ -954,7 +953,7 @@ Attributes:
   <line x1="14" y1="4" x2="14" y2="30" />
   <line x1="14" y1="4" x2="14" y2="30" />
   <line x1="14" y1="4" x2="14" y2="30" />
-  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
@@ -1042,7 +1041,7 @@ Attributes:
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
-  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
@@ -1533,7 +1532,6 @@ Attributes:
   <line x1="21" y1="11" x2="21" y2="36" />
   <line x1="21" y1="11" x2="21" y2="36" />
   <line x1="21" y1="11" x2="21" y2="36" />
-  <line x1="21" y1="11" x2="21" y2="36" />
   <line x1="21" y1="11" x2="21" y2="37" />
   <line x1="21" y1="11" x2="21" y2="37" />
   <line x1="21" y1="11" x2="21" y2="37" />
@@ -1570,7 +1568,7 @@ Attributes:
   <line x1="21" y1="11" x2="21" y2="37" />
   <line x1="21" y1="11" x2="21" y2="37" />
   <line x1="21" y1="11" x2="21" y2="37" />
-  <line x1="22" y1="12" x2="22" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
   <line x1="22" y1="12" x2="22" y2="37" />
   <line x1="22" y1="12" x2="22" y2="37" />
   <line x1="22" y1="12" x2="22" y2="37" />
@@ -1658,7 +1656,7 @@ Attributes:
   <line x1="22" y1="12" x2="22" y2="38" />
   <line x1="22" y1="12" x2="22" y2="38" />
   <line x1="22" y1="12" x2="22" y2="38" />
-  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
   <line x1="23" y1="13" x2="23" y2="38" />
   <line x1="23" y1="13" x2="23" y2="38" />
   <line x1="23" y1="13" x2="23" y2="38" />
@@ -2273,7 +2271,7 @@ Attributes:
   <line x1="29" y1="19" x2="29" y2="45" />
   <line x1="29" y1="19" x2="29" y2="45" />
   <line x1="29" y1="19" x2="29" y2="45" />
-  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
@@ -2361,7 +2359,7 @@ Attributes:
   <line x1="30" y1="20" x2="30" y2="46" />
   <line x1="30" y1="20" x2="30" y2="46" />
   <line x1="30" y1="20" x2="30" y2="46" />
-  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
@@ -2449,7 +2447,7 @@ Attributes:
   <line x1="31" y1="21" x2="31" y2="47" />
   <line x1="31" y1="21" x2="31" y2="47" />
   <line x1="31" y1="21" x2="31" y2="47" />
-  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="47" />
   <line x1="32" y1="22" x2="32" y2="47" />
   <line x1="32" y1="22" x2="32" y2="47" />
   <line x1="32" y1="22" x2="32" y2="47" />
@@ -2537,7 +2535,6 @@ Attributes:
   <line x1="32" y1="22" x2="32" y2="48" />
   <line x1="32" y1="22" x2="32" y2="48" />
   <line x1="32" y1="22" x2="32" y2="48" />
-  <line x1="32" y1="22" x2="32" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
@@ -2589,7 +2586,7 @@ Attributes:
   <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="48" />
-  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="48" />
   <line x1="33" y1="23" x2="33" y2="49" />
   <line x1="33" y1="23" x2="33" y2="49" />
   <line x1="33" y1="23" x2="33" y2="49" />
@@ -2801,7 +2798,7 @@ Attributes:
   <line x1="35" y1="25" x2="35" y2="51" />
   <line x1="35" y1="25" x2="35" y2="51" />
   <line x1="35" y1="25" x2="35" y2="51" />
-  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
   <line x1="36" y1="26" x2="36" y2="51" />
   <line x1="36" y1="26" x2="36" y2="51" />
   <line x1="36" y1="26" x2="36" y2="51" />
@@ -3292,7 +3289,6 @@ Attributes:
   <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
-  <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
@@ -3329,7 +3325,7 @@ Attributes:
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
-  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
@@ -3820,7 +3816,6 @@ Attributes:
   <line x1="47" y1="37" x2="47" y2="62" />
   <line x1="47" y1="37" x2="47" y2="62" />
   <line x1="47" y1="37" x2="47" y2="62" />
-  <line x1="47" y1="37" x2="47" y2="62" />
   <line x1="47" y1="37" x2="47" y2="63" />
   <line x1="47" y1="37" x2="47" y2="63" />
   <line x1="47" y1="37" x2="47" y2="63" />
@@ -3857,7 +3852,7 @@ Attributes:
   <line x1="47" y1="37" x2="47" y2="63" />
   <line x1="47" y1="37" x2="47" y2="63" />
   <line x1="47" y1="37" x2="47" y2="63" />
-  <line x1="48" y1="38" x2="48" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
@@ -3945,7 +3940,7 @@ Attributes:
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
-  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
@@ -4348,7 +4343,7 @@ Attributes:
   <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="68" />
-  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
@@ -4560,7 +4555,7 @@ Attributes:
   <line x1="55" y1="45" x2="55" y2="71" />
   <line x1="55" y1="45" x2="55" y2="71" />
   <line x1="55" y1="45" x2="55" y2="71" />
-  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
   <line x1="56" y1="46" x2="56" y2="71" />
   <line x1="56" y1="46" x2="56" y2="71" />
   <line x1="56" y1="46" x2="56" y2="71" />
@@ -4648,7 +4643,7 @@ Attributes:
   <line x1="56" y1="46" x2="56" y2="72" />
   <line x1="56" y1="46" x2="56" y2="72" />
   <line x1="56" y1="46" x2="56" y2="72" />
-  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
   <line x1="57" y1="47" x2="57" y2="72" />
   <line x1="57" y1="47" x2="57" y2="72" />
   <line x1="57" y1="47" x2="57" y2="72" />
@@ -4736,7 +4731,7 @@ Attributes:
   <line x1="57" y1="47" x2="57" y2="73" />
   <line x1="57" y1="47" x2="57" y2="73" />
   <line x1="57" y1="47" x2="57" y2="73" />
-  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
   <line x1="58" y1="48" x2="58" y2="73" />
   <line x1="58" y1="48" x2="58" y2="73" />
   <line x1="58" y1="48" x2="58" y2="73" />
@@ -4824,7 +4819,6 @@ Attributes:
   <line x1="58" y1="48" x2="58" y2="74" />
   <line x1="58" y1="48" x2="58" y2="74" />
   <line x1="58" y1="48" x2="58" y2="74" />
-  <line x1="58" y1="48" x2="58" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
@@ -4876,7 +4870,7 @@ Attributes:
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
-  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="75" />
   <line x1="59" y1="49" x2="59" y2="75" />
   <line x1="59" y1="49" x2="59" y2="75" />
@@ -5088,7 +5082,7 @@ Attributes:
   <line x1="61" y1="51" x2="61" y2="77" />
   <line x1="61" y1="51" x2="61" y2="77" />
   <line x1="61" y1="51" x2="61" y2="77" />
-  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
   <line x1="62" y1="52" x2="62" y2="77" />
   <line x1="62" y1="52" x2="62" y2="77" />
   <line x1="62" y1="52" x2="62" y2="77" />
@@ -5579,7 +5573,6 @@ Attributes:
   <line x1="67" y1="57" x2="67" y2="82" />
   <line x1="67" y1="57" x2="67" y2="82" />
   <line x1="67" y1="57" x2="67" y2="82" />
-  <line x1="67" y1="57" x2="67" y2="82" />
   <line x1="67" y1="57" x2="67" y2="83" />
   <line x1="67" y1="57" x2="67" y2="83" />
   <line x1="67" y1="57" x2="67" y2="83" />
@@ -5616,7 +5609,7 @@ Attributes:
   <line x1="67" y1="57" x2="67" y2="83" />
   <line x1="67" y1="57" x2="67" y2="83" />
   <line x1="67" y1="57" x2="67" y2="83" />
-  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
   <line x1="68" y1="58" x2="68" y2="83" />
   <line x1="68" y1="58" x2="68" y2="83" />
   <line x1="68" y1="58" x2="68" y2="83" />
@@ -5704,7 +5697,7 @@ Attributes:
   <line x1="68" y1="58" x2="68" y2="84" />
   <line x1="68" y1="58" x2="68" y2="84" />
   <line x1="68" y1="58" x2="68" y2="84" />
-  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
   <line x1="69" y1="59" x2="69" y2="84" />
   <line x1="69" y1="59" x2="69" y2="84" />
   <line x1="69" y1="59" x2="69" y2="84" />
@@ -6107,7 +6100,6 @@ Attributes:
   <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
-  <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
@@ -6144,7 +6136,7 @@ Attributes:
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
-  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
@@ -6232,7 +6224,7 @@ Attributes:
   <line x1="74" y1="64" x2="74" y2="90" />
   <line x1="74" y1="64" x2="74" y2="90" />
   <line x1="74" y1="64" x2="74" y2="90" />
-  <line x1="75" y1="65" x2="75" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
   <line x1="75" y1="65" x2="75" y2="90" />
   <line x1="75" y1="65" x2="75" y2="90" />
   <line x1="75" y1="65" x2="75" y2="90" />
@@ -6635,7 +6627,7 @@ Attributes:
   <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="94" />
-  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="95" />
   <line x1="79" y1="69" x2="79" y2="95" />
   <line x1="79" y1="69" x2="79" y2="95" />
@@ -7132,7 +7124,6 @@ Attributes:
   <line x1="14" y1="4" x2="39" y2="4" />
   <line x1="14" y1="4" x2="39" y2="4" />
   <line x1="14" y1="4" x2="39" y2="4" />
-  <line x1="14" y1="4" x2="39" y2="4" />
   <line x1="14" y1="4" x2="40" y2="4" />
   <line x1="14" y1="4" x2="40" y2="4" />
   <line x1="14" y1="4" x2="40" y2="4" />
@@ -7169,7 +7160,7 @@ Attributes:
   <line x1="14" y1="4" x2="40" y2="4" />
   <line x1="14" y1="4" x2="40" y2="4" />
   <line x1="14" y1="4" x2="40" y2="4" />
-  <line x1="15" y1="5" x2="40" y2="5" />
+  <line x1="14" y1="4" x2="40" y2="4" />
   <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="40" y2="5" />
@@ -7257,7 +7248,7 @@ Attributes:
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
-  <line x1="16" y1="6" x2="41" y2="6" />
+  <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="16" y1="6" x2="41" y2="6" />
   <line x1="16" y1="6" x2="41" y2="6" />
   <line x1="16" y1="6" x2="41" y2="6" />
@@ -7748,7 +7739,6 @@ Attributes:
   <line x1="21" y1="11" x2="46" y2="11" />
   <line x1="21" y1="11" x2="46" y2="11" />
   <line x1="21" y1="11" x2="46" y2="11" />
-  <line x1="21" y1="11" x2="46" y2="11" />
   <line x1="21" y1="11" x2="47" y2="11" />
   <line x1="21" y1="11" x2="47" y2="11" />
   <line x1="21" y1="11" x2="47" y2="11" />
@@ -7785,7 +7775,7 @@ Attributes:
   <line x1="21" y1="11" x2="47" y2="11" />
   <line x1="21" y1="11" x2="47" y2="11" />
   <line x1="21" y1="11" x2="47" y2="11" />
-  <line x1="22" y1="12" x2="47" y2="12" />
+  <line x1="21" y1="11" x2="47" y2="11" />
   <line x1="22" y1="12" x2="47" y2="12" />
   <line x1="22" y1="12" x2="47" y2="12" />
   <line x1="22" y1="12" x2="47" y2="12" />
@@ -7873,7 +7863,7 @@ Attributes:
   <line x1="22" y1="12" x2="48" y2="12" />
   <line x1="22" y1="12" x2="48" y2="12" />
   <line x1="22" y1="12" x2="48" y2="12" />
-  <line x1="23" y1="13" x2="48" y2="13" />
+  <line x1="22" y1="12" x2="48" y2="12" />
   <line x1="23" y1="13" x2="48" y2="13" />
   <line x1="23" y1="13" x2="48" y2="13" />
   <line x1="23" y1="13" x2="48" y2="13" />
@@ -8488,7 +8478,7 @@ Attributes:
   <line x1="29" y1="19" x2="55" y2="19" />
   <line x1="29" y1="19" x2="55" y2="19" />
   <line x1="29" y1="19" x2="55" y2="19" />
-  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
@@ -8576,7 +8566,7 @@ Attributes:
   <line x1="30" y1="20" x2="56" y2="20" />
   <line x1="30" y1="20" x2="56" y2="20" />
   <line x1="30" y1="20" x2="56" y2="20" />
-  <line x1="30" y1="20" x2="56" y2="20" />
+  <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
@@ -8664,7 +8654,7 @@ Attributes:
   <line x1="31" y1="21" x2="57" y2="21" />
   <line x1="31" y1="21" x2="57" y2="21" />
   <line x1="31" y1="21" x2="57" y2="21" />
-  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="32" y1="22" x2="57" y2="22" />
   <line x1="32" y1="22" x2="57" y2="22" />
   <line x1="32" y1="22" x2="57" y2="22" />
   <line x1="32" y1="22" x2="57" y2="22" />
@@ -8752,7 +8742,6 @@ Attributes:
   <line x1="32" y1="22" x2="58" y2="22" />
   <line x1="32" y1="22" x2="58" y2="22" />
   <line x1="32" y1="22" x2="58" y2="22" />
-  <line x1="32" y1="22" x2="58" y2="22" />
   <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="58" y2="23" />
@@ -8804,7 +8793,7 @@ Attributes:
   <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="58" y2="23" />
-  <line x1="33" y1="23" x2="59" y2="23" />
+  <line x1="33" y1="23" x2="58" y2="23" />
   <line x1="33" y1="23" x2="59" y2="23" />
   <line x1="33" y1="23" x2="59" y2="23" />
   <line x1="33" y1="23" x2="59" y2="23" />
@@ -9016,7 +9005,7 @@ Attributes:
   <line x1="35" y1="25" x2="61" y2="25" />
   <line x1="35" y1="25" x2="61" y2="25" />
   <line x1="35" y1="25" x2="61" y2="25" />
-  <line x1="36" y1="26" x2="61" y2="26" />
+  <line x1="35" y1="25" x2="61" y2="25" />
   <line x1="36" y1="26" x2="61" y2="26" />
   <line x1="36" y1="26" x2="61" y2="26" />
   <line x1="36" y1="26" x2="61" y2="26" />
@@ -9507,7 +9496,6 @@ Attributes:
   <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="66" y2="31" />
-  <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
@@ -9544,7 +9532,7 @@ Attributes:
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
-  <line x1="42" y1="32" x2="67" y2="32" />
+  <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="42" y1="32" x2="67" y2="32" />
   <line x1="42" y1="32" x2="67" y2="32" />
   <line x1="42" y1="32" x2="67" y2="32" />
@@ -10035,7 +10023,6 @@ Attributes:
   <line x1="47" y1="37" x2="72" y2="37" />
   <line x1="47" y1="37" x2="72" y2="37" />
   <line x1="47" y1="37" x2="72" y2="37" />
-  <line x1="47" y1="37" x2="72" y2="37" />
   <line x1="47" y1="37" x2="73" y2="37" />
   <line x1="47" y1="37" x2="73" y2="37" />
   <line x1="47" y1="37" x2="73" y2="37" />
@@ -10072,7 +10059,7 @@ Attributes:
   <line x1="47" y1="37" x2="73" y2="37" />
   <line x1="47" y1="37" x2="73" y2="37" />
   <line x1="47" y1="37" x2="73" y2="37" />
-  <line x1="48" y1="38" x2="73" y2="38" />
+  <line x1="47" y1="37" x2="73" y2="37" />
   <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="73" y2="38" />
@@ -10160,7 +10147,7 @@ Attributes:
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
-  <line x1="49" y1="39" x2="74" y2="39" />
+  <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="49" y1="39" x2="74" y2="39" />
   <line x1="49" y1="39" x2="74" y2="39" />
   <line x1="49" y1="39" x2="74" y2="39" />
@@ -10563,7 +10550,7 @@ Attributes:
   <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="78" y2="43" />
-  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
@@ -10775,7 +10762,7 @@ Attributes:
   <line x1="55" y1="45" x2="81" y2="45" />
   <line x1="55" y1="45" x2="81" y2="45" />
   <line x1="55" y1="45" x2="81" y2="45" />
-  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="56" y1="46" x2="81" y2="46" />
   <line x1="56" y1="46" x2="81" y2="46" />
   <line x1="56" y1="46" x2="81" y2="46" />
   <line x1="56" y1="46" x2="81" y2="46" />
@@ -10863,7 +10850,7 @@ Attributes:
   <line x1="56" y1="46" x2="82" y2="46" />
   <line x1="56" y1="46" x2="82" y2="46" />
   <line x1="56" y1="46" x2="82" y2="46" />
-  <line x1="56" y1="46" x2="82" y2="46" />
+  <line x1="57" y1="47" x2="82" y2="47" />
   <line x1="57" y1="47" x2="82" y2="47" />
   <line x1="57" y1="47" x2="82" y2="47" />
   <line x1="57" y1="47" x2="82" y2="47" />
@@ -10951,7 +10938,7 @@ Attributes:
   <line x1="57" y1="47" x2="83" y2="47" />
   <line x1="57" y1="47" x2="83" y2="47" />
   <line x1="57" y1="47" x2="83" y2="47" />
-  <line x1="57" y1="47" x2="83" y2="47" />
+  <line x1="58" y1="48" x2="83" y2="48" />
   <line x1="58" y1="48" x2="83" y2="48" />
   <line x1="58" y1="48" x2="83" y2="48" />
   <line x1="58" y1="48" x2="83" y2="48" />
@@ -11039,7 +11026,6 @@ Attributes:
   <line x1="58" y1="48" x2="84" y2="48" />
   <line x1="58" y1="48" x2="84" y2="48" />
   <line x1="58" y1="48" x2="84" y2="48" />
-  <line x1="58" y1="48" x2="84" y2="48" />
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
@@ -11091,7 +11077,7 @@ Attributes:
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
-  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="85" y2="49" />
   <line x1="59" y1="49" x2="85" y2="49" />
   <line x1="59" y1="49" x2="85" y2="49" />
@@ -11303,7 +11289,7 @@ Attributes:
   <line x1="61" y1="51" x2="87" y2="51" />
   <line x1="61" y1="51" x2="87" y2="51" />
   <line x1="61" y1="51" x2="87" y2="51" />
-  <line x1="62" y1="52" x2="87" y2="52" />
+  <line x1="61" y1="51" x2="87" y2="51" />
   <line x1="62" y1="52" x2="87" y2="52" />
   <line x1="62" y1="52" x2="87" y2="52" />
   <line x1="62" y1="52" x2="87" y2="52" />
@@ -11794,7 +11780,6 @@ Attributes:
   <line x1="67" y1="57" x2="92" y2="57" />
   <line x1="67" y1="57" x2="92" y2="57" />
   <line x1="67" y1="57" x2="92" y2="57" />
-  <line x1="67" y1="57" x2="92" y2="57" />
   <line x1="67" y1="57" x2="93" y2="57" />
   <line x1="67" y1="57" x2="93" y2="57" />
   <line x1="67" y1="57" x2="93" y2="57" />
@@ -11831,7 +11816,7 @@ Attributes:
   <line x1="67" y1="57" x2="93" y2="57" />
   <line x1="67" y1="57" x2="93" y2="57" />
   <line x1="67" y1="57" x2="93" y2="57" />
-  <line x1="68" y1="58" x2="93" y2="58" />
+  <line x1="67" y1="57" x2="93" y2="57" />
   <line x1="68" y1="58" x2="93" y2="58" />
   <line x1="68" y1="58" x2="93" y2="58" />
   <line x1="68" y1="58" x2="93" y2="58" />
@@ -11919,7 +11904,7 @@ Attributes:
   <line x1="68" y1="58" x2="94" y2="58" />
   <line x1="68" y1="58" x2="94" y2="58" />
   <line x1="68" y1="58" x2="94" y2="58" />
-  <line x1="69" y1="59" x2="94" y2="59" />
+  <line x1="68" y1="58" x2="94" y2="58" />
   <line x1="69" y1="59" x2="94" y2="59" />
   <line x1="69" y1="59" x2="94" y2="59" />
   <line x1="69" y1="59" x2="94" y2="59" />
@@ -12322,7 +12307,6 @@ Attributes:
   <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="98" y2="63" />
-  <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
@@ -12359,7 +12343,7 @@ Attributes:
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
-  <line x1="74" y1="64" x2="99" y2="64" />
+  <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="74" y1="64" x2="99" y2="64" />
   <line x1="74" y1="64" x2="99" y2="64" />
   <line x1="74" y1="64" x2="99" y2="64" />
@@ -12447,7 +12431,7 @@ Attributes:
   <line x1="74" y1="64" x2="100" y2="64" />
   <line x1="74" y1="64" x2="100" y2="64" />
   <line x1="74" y1="64" x2="100" y2="64" />
-  <line x1="75" y1="65" x2="100" y2="65" />
+  <line x1="74" y1="64" x2="100" y2="64" />
   <line x1="75" y1="65" x2="100" y2="65" />
   <line x1="75" y1="65" x2="100" y2="65" />
   <line x1="75" y1="65" x2="100" y2="65" />
@@ -12850,7 +12834,7 @@ Attributes:
   <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="104" y2="69" />
-  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
@@ -12961,11 +12945,11 @@ Attributes:
   <!-- Text -->
   <text x="93.294544" y="116.000852" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
   <text x="126.000852" y="83.294544" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,126.000852,83.294544)">181</text>
-  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">279405</text>
+  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">279045</text>
 </svg>
 </td>
 </tr>
-</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-84a2c2f1-1856-4eb8-9147-7610d9be0d72' class='xr-section-summary-in' type='checkbox'  checked><label for='section-84a2c2f1-1856-4eb8-9147-7610d9be0d72' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/07/14 07:17:37</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8ec9983c-4ce3-4af1-a2ec-b047531bf51c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8ec9983c-4ce3-4af1-a2ec-b047531bf51c' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/03/27 18:39:04</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
     
 
 

--- a/ua_200_RSMAS-CCSM4_.anoms.daily.e2.nc.html
+++ b/ua_200_RSMAS-CCSM4_.anoms.daily.e2.nc.html
@@ -51,7 +51,7 @@
 
 <li><a href=subx_hindcast_ua200_daily_anoms>subx_hindcast_ua200_daily_anoms</a></li>
 
-<li><a href=subx_hindcast_ua200_daily_anoms_nrl-nesm>subx_hindcast_ua200_daily_anoms_nrl-nesm</a></li>
+<li><a href=subx_hindcast_ua200_daily_anoms_rsmas-ccsm4>subx_hindcast_ua200_daily_anoms_rsmas-ccsm4</a></li>
 
 
             <li class="active">SubX Anomalies</li>
@@ -64,7 +64,7 @@
 
         <h3>Load in Python</h3>
         <pre><code class="language-python">from intake import open_catalog<br>
-cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_NRL-NESM_anoms.daily.yaml")
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_RSMAS-CCSM4_anoms.daily.e2.yaml")
 ds=cat.netcdf.read()</code></pre>
 
         <h3>Metadata</h3>
@@ -78,7 +78,7 @@ ds=cat.netcdf.read()</code></pre>
 
             <tr>
                 <td>location</td>
-                <td>/shared/subx/hindcast/ua200/daily/anoms/NRL-NESM</td>
+                <td>/shared/subx/hindcast/ua200/daily/anoms/RSMAS-CCSM4</td>
             </tr>
 
             <tr>
@@ -88,13 +88,13 @@ ds=cat.netcdf.read()</code></pre>
 
             <tr>
                 <td>catalog_dir</td>
-                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_NRL-NESM_anoms.daily.yaml</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_200_RSMAS-CCSM4_anoms.daily.e2.yaml</td>
             </tr>
     
 
             <tr>
                 <td>last updated </td>
-                <td>2018-07-14</td>
+                <td>2018-07-12</td>
             </tr>
 
 
@@ -461,7 +461,7 @@ dl.xr-attrs {
   fill: currentColor;
 }
 </style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
-Dimensions:  (lat: 181, lon: 360, time: 279405)
+Dimensions:  (lat: 181, lon: 360, time: 279135)
 Coordinates:
   * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
   * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
@@ -474,9 +474,9 @@ Attributes:
     comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
     institution:   IRI
     source:        SubX IRI
-    CreationDate:  2018/07/14 07:17:37
+    CreationDate:  2018/03/24 00:57:06
     CreatedBy:     kpegion
-    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f1be56f8-cf7a-48a7-bf9a-c6ac4d666835' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f1be56f8-cf7a-48a7-bf9a-c6ac4d666835' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 279405</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4333d037-1eb3-4eee-b921-408db2c9f1f8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4333d037-1eb3-4eee-b921-408db2c9f1f8' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-9f5dc649-5581-4c0f-b827-076115a750fc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9f5dc649-5581-4c0f-b827-076115a750fc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bfdcc22f-e7d6-4d5f-a2d0-5aa3747dbac5' class='xr-var-data-in' type='checkbox'><label for='data-bfdcc22f-e7d6-4d5f-a2d0-5aa3747dbac5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-d7375a96-fd7c-4435-bf79-a15be8000d85' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d7375a96-fd7c-4435-bf79-a15be8000d85' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 279135</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-d51f1ffc-19b6-4e5f-979a-102eaddaba60' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d51f1ffc-19b6-4e5f-979a-102eaddaba60' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-8e80f3a1-03d7-444a-ae57-08b046a62726' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8e80f3a1-03d7-444a-ae57-08b046a62726' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c46558b8-5dbb-4de9-93b6-5b1fb53ed9f6' class='xr-var-data-in' type='checkbox'><label for='data-c46558b8-5dbb-4de9-93b6-5b1fb53ed9f6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
        -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
        -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
        -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
@@ -491,7 +491,7 @@ Attributes:
         54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
         66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
         78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
-        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-455b950b-5ee5-44c8-9906-92795e208705' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-455b950b-5ee5-44c8-9906-92795e208705' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-28d6b6a8-5041-4fc6-ad01-db31ecb0b541' class='xr-var-data-in' type='checkbox'><label for='data-28d6b6a8-5041-4fc6-ad01-db31ecb0b541' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-2c10cb96-b5da-484a-ad02-e243f4035bfd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2c10cb96-b5da-484a-ad02-e243f4035bfd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e2282ec9-2cec-4b13-b9a9-6aa3d71d0309' class='xr-var-data-in' type='checkbox'><label for='data-e2282ec9-2cec-4b13-b9a9-6aa3d71d0309' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-61f7f6f4-b0bb-4d6f-9d83-519f7d744f21' class='xr-section-summary-in' type='checkbox'  checked><label for='section-61f7f6f4-b0bb-4d6f-9d83-519f7d744f21' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-ee839924-4e45-4033-86ad-78e4b72d0c1d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee839924-4e45-4033-86ad-78e4b72d0c1d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b9ccdcf8-0938-4685-acad-fae5ef968a9e' class='xr-var-data-in' type='checkbox'><label for='data-b9ccdcf8-0938-4685-acad-fae5ef968a9e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m/s</dd></dl></div><div class='xr-var-data'><table>
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-7b98de77-986f-4b9f-afa6-47f5459b9f4d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7b98de77-986f-4b9f-afa6-47f5459b9f4d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-47f0e5bc-b9ff-4c9a-9b15-17a0af3529eb' class='xr-var-data-in' type='checkbox'><label for='data-47f0e5bc-b9ff-4c9a-9b15-17a0af3529eb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-00725475-2448-49b7-a725-b310d1052f19' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-00725475-2448-49b7-a725-b310d1052f19' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c914642a-c1f5-4ef3-87ec-514f98cfb4a1' class='xr-var-data-in' type='checkbox'><label for='data-c914642a-c1f5-4ef3-87ec-514f98cfb4a1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-47be4cf4-0d3a-4149-b3d7-bcd7c7512345' class='xr-section-summary-in' type='checkbox'  checked><label for='section-47be4cf4-0d3a-4149-b3d7-bcd7c7512345' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-2c99db51-e276-419a-9ea2-72666a8c13d2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2c99db51-e276-419a-9ea2-72666a8c13d2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-20dc7f56-9f59-411f-8c94-9dd106630308' class='xr-var-data-in' type='checkbox'><label for='data-20dc7f56-9f59-411f-8c94-9dd106630308' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>m s-1</dd></dl></div><div class='xr-var-data'><table>
 <tr>
 <td>
 <table>
@@ -499,9 +499,9 @@ Attributes:
     <tr><td> </td><th> Array </th><th> Chunk </th></tr>
   </thead>
   <tbody>
-    <tr><th> Bytes </th><td> 72.82 GB </td> <td> 11.73 MB </td></tr>
-    <tr><th> Shape </th><td> (279405, 181, 360) </td> <td> (45, 181, 360) </td></tr>
-    <tr><th> Count </th><td> 18627 Tasks </td><td> 6209 Chunks </td></tr>
+    <tr><th> Bytes </th><td> 72.75 GB </td> <td> 11.73 MB </td></tr>
+    <tr><th> Shape </th><td> (279135, 181, 360) </td> <td> (45, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 18609 Tasks </td><td> 6203 Chunks </td></tr>
     <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
   </tbody>
 </table>
@@ -1005,7 +1005,6 @@ Attributes:
   <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="30" />
-  <line x1="15" y1="5" x2="15" y2="30" />
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
@@ -1042,7 +1041,7 @@ Attributes:
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="15" y1="5" x2="15" y2="31" />
-  <line x1="16" y1="6" x2="16" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
   <line x1="16" y1="6" x2="16" y2="31" />
@@ -1130,7 +1129,7 @@ Attributes:
   <line x1="16" y1="6" x2="16" y2="32" />
   <line x1="16" y1="6" x2="16" y2="32" />
   <line x1="16" y1="6" x2="16" y2="32" />
-  <line x1="17" y1="7" x2="17" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
   <line x1="17" y1="7" x2="17" y2="32" />
   <line x1="17" y1="7" x2="17" y2="32" />
   <line x1="17" y1="7" x2="17" y2="32" />
@@ -1218,7 +1217,7 @@ Attributes:
   <line x1="17" y1="7" x2="17" y2="33" />
   <line x1="17" y1="7" x2="17" y2="33" />
   <line x1="17" y1="7" x2="17" y2="33" />
-  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
   <line x1="18" y1="8" x2="18" y2="33" />
   <line x1="18" y1="8" x2="18" y2="33" />
   <line x1="18" y1="8" x2="18" y2="33" />
@@ -1797,7 +1796,6 @@ Attributes:
   <line x1="24" y1="14" x2="24" y2="39" />
   <line x1="24" y1="14" x2="24" y2="39" />
   <line x1="24" y1="14" x2="24" y2="39" />
-  <line x1="24" y1="14" x2="24" y2="39" />
   <line x1="24" y1="14" x2="24" y2="40" />
   <line x1="24" y1="14" x2="24" y2="40" />
   <line x1="24" y1="14" x2="24" y2="40" />
@@ -1834,7 +1832,7 @@ Attributes:
   <line x1="24" y1="14" x2="24" y2="40" />
   <line x1="24" y1="14" x2="24" y2="40" />
   <line x1="24" y1="14" x2="24" y2="40" />
-  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
   <line x1="25" y1="15" x2="25" y2="40" />
   <line x1="25" y1="15" x2="25" y2="40" />
   <line x1="25" y1="15" x2="25" y2="40" />
@@ -1922,7 +1920,7 @@ Attributes:
   <line x1="25" y1="15" x2="25" y2="41" />
   <line x1="25" y1="15" x2="25" y2="41" />
   <line x1="25" y1="15" x2="25" y2="41" />
-  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
   <line x1="26" y1="16" x2="26" y2="41" />
   <line x1="26" y1="16" x2="26" y2="41" />
   <line x1="26" y1="16" x2="26" y2="41" />
@@ -2149,6 +2147,7 @@ Attributes:
   <line x1="28" y1="18" x2="28" y2="43" />
   <line x1="28" y1="18" x2="28" y2="43" />
   <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
   <line x1="28" y1="18" x2="28" y2="44" />
   <line x1="28" y1="18" x2="28" y2="44" />
   <line x1="28" y1="18" x2="28" y2="44" />
@@ -2185,7 +2184,7 @@ Attributes:
   <line x1="28" y1="18" x2="28" y2="44" />
   <line x1="28" y1="18" x2="28" y2="44" />
   <line x1="28" y1="18" x2="28" y2="44" />
-  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
   <line x1="29" y1="19" x2="29" y2="44" />
   <line x1="29" y1="19" x2="29" y2="44" />
   <line x1="29" y1="19" x2="29" y2="44" />
@@ -2273,7 +2272,7 @@ Attributes:
   <line x1="29" y1="19" x2="29" y2="45" />
   <line x1="29" y1="19" x2="29" y2="45" />
   <line x1="29" y1="19" x2="29" y2="45" />
-  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
   <line x1="30" y1="20" x2="30" y2="45" />
@@ -2361,7 +2360,6 @@ Attributes:
   <line x1="30" y1="20" x2="30" y2="46" />
   <line x1="30" y1="20" x2="30" y2="46" />
   <line x1="30" y1="20" x2="30" y2="46" />
-  <line x1="30" y1="20" x2="30" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
@@ -2413,7 +2411,7 @@ Attributes:
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="46" />
-  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="46" />
   <line x1="31" y1="21" x2="31" y2="47" />
   <line x1="31" y1="21" x2="31" y2="47" />
   <line x1="31" y1="21" x2="31" y2="47" />
@@ -2713,7 +2711,7 @@ Attributes:
   <line x1="34" y1="24" x2="34" y2="50" />
   <line x1="34" y1="24" x2="34" y2="50" />
   <line x1="34" y1="24" x2="34" y2="50" />
-  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
   <line x1="35" y1="25" x2="35" y2="50" />
   <line x1="35" y1="25" x2="35" y2="50" />
   <line x1="35" y1="25" x2="35" y2="50" />
@@ -3204,7 +3202,6 @@ Attributes:
   <line x1="40" y1="30" x2="40" y2="55" />
   <line x1="40" y1="30" x2="40" y2="55" />
   <line x1="40" y1="30" x2="40" y2="55" />
-  <line x1="40" y1="30" x2="40" y2="55" />
   <line x1="40" y1="30" x2="40" y2="56" />
   <line x1="40" y1="30" x2="40" y2="56" />
   <line x1="40" y1="30" x2="40" y2="56" />
@@ -3241,7 +3238,7 @@ Attributes:
   <line x1="40" y1="30" x2="40" y2="56" />
   <line x1="40" y1="30" x2="40" y2="56" />
   <line x1="40" y1="30" x2="40" y2="56" />
-  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
   <line x1="41" y1="31" x2="41" y2="56" />
@@ -3329,7 +3326,7 @@ Attributes:
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="41" y1="31" x2="41" y2="57" />
-  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
   <line x1="42" y1="32" x2="42" y2="57" />
@@ -3908,7 +3905,6 @@ Attributes:
   <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="63" />
-  <line x1="48" y1="38" x2="48" y2="63" />
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
@@ -3945,7 +3941,7 @@ Attributes:
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="48" y1="38" x2="48" y2="64" />
-  <line x1="49" y1="39" x2="49" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
   <line x1="49" y1="39" x2="49" y2="64" />
@@ -4033,7 +4029,7 @@ Attributes:
   <line x1="49" y1="39" x2="49" y2="65" />
   <line x1="49" y1="39" x2="49" y2="65" />
   <line x1="49" y1="39" x2="49" y2="65" />
-  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
   <line x1="50" y1="40" x2="50" y2="65" />
   <line x1="50" y1="40" x2="50" y2="65" />
   <line x1="50" y1="40" x2="50" y2="65" />
@@ -4348,6 +4344,7 @@ Attributes:
   <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
@@ -4384,7 +4381,7 @@ Attributes:
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
   <line x1="53" y1="43" x2="53" y2="69" />
-  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="69" />
   <line x1="54" y1="44" x2="54" y2="69" />
   <line x1="54" y1="44" x2="54" y2="69" />
   <line x1="54" y1="44" x2="54" y2="69" />
@@ -4472,7 +4469,6 @@ Attributes:
   <line x1="54" y1="44" x2="54" y2="70" />
   <line x1="54" y1="44" x2="54" y2="70" />
   <line x1="54" y1="44" x2="54" y2="70" />
-  <line x1="54" y1="44" x2="54" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
@@ -4524,7 +4520,7 @@ Attributes:
   <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="70" />
-  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="70" />
   <line x1="55" y1="45" x2="55" y2="71" />
   <line x1="55" y1="45" x2="55" y2="71" />
   <line x1="55" y1="45" x2="55" y2="71" />
@@ -4824,7 +4820,7 @@ Attributes:
   <line x1="58" y1="48" x2="58" y2="74" />
   <line x1="58" y1="48" x2="58" y2="74" />
   <line x1="58" y1="48" x2="58" y2="74" />
-  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
   <line x1="59" y1="49" x2="59" y2="74" />
@@ -4912,7 +4908,7 @@ Attributes:
   <line x1="59" y1="49" x2="59" y2="75" />
   <line x1="59" y1="49" x2="59" y2="75" />
   <line x1="59" y1="49" x2="59" y2="75" />
-  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="75" />
   <line x1="60" y1="50" x2="60" y2="75" />
   <line x1="60" y1="50" x2="60" y2="75" />
   <line x1="60" y1="50" x2="60" y2="75" />
@@ -5000,7 +4996,7 @@ Attributes:
   <line x1="60" y1="50" x2="60" y2="76" />
   <line x1="60" y1="50" x2="60" y2="76" />
   <line x1="60" y1="50" x2="60" y2="76" />
-  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
   <line x1="61" y1="51" x2="61" y2="76" />
@@ -5315,7 +5311,6 @@ Attributes:
   <line x1="64" y1="54" x2="64" y2="79" />
   <line x1="64" y1="54" x2="64" y2="79" />
   <line x1="64" y1="54" x2="64" y2="79" />
-  <line x1="64" y1="54" x2="64" y2="79" />
   <line x1="64" y1="54" x2="64" y2="80" />
   <line x1="64" y1="54" x2="64" y2="80" />
   <line x1="64" y1="54" x2="64" y2="80" />
@@ -5352,7 +5347,7 @@ Attributes:
   <line x1="64" y1="54" x2="64" y2="80" />
   <line x1="64" y1="54" x2="64" y2="80" />
   <line x1="64" y1="54" x2="64" y2="80" />
-  <line x1="65" y1="55" x2="65" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
   <line x1="65" y1="55" x2="65" y2="80" />
   <line x1="65" y1="55" x2="65" y2="80" />
   <line x1="65" y1="55" x2="65" y2="80" />
@@ -5440,7 +5435,7 @@ Attributes:
   <line x1="65" y1="55" x2="65" y2="81" />
   <line x1="65" y1="55" x2="65" y2="81" />
   <line x1="65" y1="55" x2="65" y2="81" />
-  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
   <line x1="66" y1="56" x2="66" y2="81" />
   <line x1="66" y1="56" x2="66" y2="81" />
   <line x1="66" y1="56" x2="66" y2="81" />
@@ -6019,7 +6014,6 @@ Attributes:
   <line x1="72" y1="62" x2="72" y2="87" />
   <line x1="72" y1="62" x2="72" y2="87" />
   <line x1="72" y1="62" x2="72" y2="87" />
-  <line x1="72" y1="62" x2="72" y2="87" />
   <line x1="72" y1="62" x2="72" y2="88" />
   <line x1="72" y1="62" x2="72" y2="88" />
   <line x1="72" y1="62" x2="72" y2="88" />
@@ -6056,7 +6050,7 @@ Attributes:
   <line x1="72" y1="62" x2="72" y2="88" />
   <line x1="72" y1="62" x2="72" y2="88" />
   <line x1="72" y1="62" x2="72" y2="88" />
-  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
   <line x1="73" y1="63" x2="73" y2="88" />
@@ -6144,7 +6138,7 @@ Attributes:
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="73" y1="63" x2="73" y2="89" />
-  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
   <line x1="74" y1="64" x2="74" y2="89" />
@@ -6635,7 +6629,7 @@ Attributes:
   <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="94" />
-  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="94" />
   <line x1="79" y1="69" x2="79" y2="95" />
   <line x1="79" y1="69" x2="79" y2="95" />
   <line x1="79" y1="69" x2="79" y2="95" />
@@ -7220,7 +7214,6 @@ Attributes:
   <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="40" y2="5" />
-  <line x1="15" y1="5" x2="40" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
@@ -7257,7 +7250,7 @@ Attributes:
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="15" y1="5" x2="41" y2="5" />
-  <line x1="16" y1="6" x2="41" y2="6" />
+  <line x1="15" y1="5" x2="41" y2="5" />
   <line x1="16" y1="6" x2="41" y2="6" />
   <line x1="16" y1="6" x2="41" y2="6" />
   <line x1="16" y1="6" x2="41" y2="6" />
@@ -7345,7 +7338,7 @@ Attributes:
   <line x1="16" y1="6" x2="42" y2="6" />
   <line x1="16" y1="6" x2="42" y2="6" />
   <line x1="16" y1="6" x2="42" y2="6" />
-  <line x1="17" y1="7" x2="42" y2="7" />
+  <line x1="16" y1="6" x2="42" y2="6" />
   <line x1="17" y1="7" x2="42" y2="7" />
   <line x1="17" y1="7" x2="42" y2="7" />
   <line x1="17" y1="7" x2="42" y2="7" />
@@ -7433,7 +7426,7 @@ Attributes:
   <line x1="17" y1="7" x2="43" y2="7" />
   <line x1="17" y1="7" x2="43" y2="7" />
   <line x1="17" y1="7" x2="43" y2="7" />
-  <line x1="18" y1="8" x2="43" y2="8" />
+  <line x1="17" y1="7" x2="43" y2="7" />
   <line x1="18" y1="8" x2="43" y2="8" />
   <line x1="18" y1="8" x2="43" y2="8" />
   <line x1="18" y1="8" x2="43" y2="8" />
@@ -8012,7 +8005,6 @@ Attributes:
   <line x1="24" y1="14" x2="49" y2="14" />
   <line x1="24" y1="14" x2="49" y2="14" />
   <line x1="24" y1="14" x2="49" y2="14" />
-  <line x1="24" y1="14" x2="49" y2="14" />
   <line x1="24" y1="14" x2="50" y2="14" />
   <line x1="24" y1="14" x2="50" y2="14" />
   <line x1="24" y1="14" x2="50" y2="14" />
@@ -8049,7 +8041,7 @@ Attributes:
   <line x1="24" y1="14" x2="50" y2="14" />
   <line x1="24" y1="14" x2="50" y2="14" />
   <line x1="24" y1="14" x2="50" y2="14" />
-  <line x1="25" y1="15" x2="50" y2="15" />
+  <line x1="24" y1="14" x2="50" y2="14" />
   <line x1="25" y1="15" x2="50" y2="15" />
   <line x1="25" y1="15" x2="50" y2="15" />
   <line x1="25" y1="15" x2="50" y2="15" />
@@ -8137,7 +8129,7 @@ Attributes:
   <line x1="25" y1="15" x2="51" y2="15" />
   <line x1="25" y1="15" x2="51" y2="15" />
   <line x1="25" y1="15" x2="51" y2="15" />
-  <line x1="26" y1="16" x2="51" y2="16" />
+  <line x1="25" y1="15" x2="51" y2="15" />
   <line x1="26" y1="16" x2="51" y2="16" />
   <line x1="26" y1="16" x2="51" y2="16" />
   <line x1="26" y1="16" x2="51" y2="16" />
@@ -8364,6 +8356,7 @@ Attributes:
   <line x1="28" y1="18" x2="53" y2="18" />
   <line x1="28" y1="18" x2="53" y2="18" />
   <line x1="28" y1="18" x2="53" y2="18" />
+  <line x1="28" y1="18" x2="53" y2="18" />
   <line x1="28" y1="18" x2="54" y2="18" />
   <line x1="28" y1="18" x2="54" y2="18" />
   <line x1="28" y1="18" x2="54" y2="18" />
@@ -8400,7 +8393,7 @@ Attributes:
   <line x1="28" y1="18" x2="54" y2="18" />
   <line x1="28" y1="18" x2="54" y2="18" />
   <line x1="28" y1="18" x2="54" y2="18" />
-  <line x1="28" y1="18" x2="54" y2="18" />
+  <line x1="29" y1="19" x2="54" y2="19" />
   <line x1="29" y1="19" x2="54" y2="19" />
   <line x1="29" y1="19" x2="54" y2="19" />
   <line x1="29" y1="19" x2="54" y2="19" />
@@ -8488,7 +8481,7 @@ Attributes:
   <line x1="29" y1="19" x2="55" y2="19" />
   <line x1="29" y1="19" x2="55" y2="19" />
   <line x1="29" y1="19" x2="55" y2="19" />
-  <line x1="29" y1="19" x2="55" y2="19" />
+  <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
   <line x1="30" y1="20" x2="55" y2="20" />
@@ -8576,7 +8569,6 @@ Attributes:
   <line x1="30" y1="20" x2="56" y2="20" />
   <line x1="30" y1="20" x2="56" y2="20" />
   <line x1="30" y1="20" x2="56" y2="20" />
-  <line x1="30" y1="20" x2="56" y2="20" />
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
@@ -8628,7 +8620,7 @@ Attributes:
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="56" y2="21" />
-  <line x1="31" y1="21" x2="57" y2="21" />
+  <line x1="31" y1="21" x2="56" y2="21" />
   <line x1="31" y1="21" x2="57" y2="21" />
   <line x1="31" y1="21" x2="57" y2="21" />
   <line x1="31" y1="21" x2="57" y2="21" />
@@ -8928,7 +8920,7 @@ Attributes:
   <line x1="34" y1="24" x2="60" y2="24" />
   <line x1="34" y1="24" x2="60" y2="24" />
   <line x1="34" y1="24" x2="60" y2="24" />
-  <line x1="34" y1="24" x2="60" y2="24" />
+  <line x1="35" y1="25" x2="60" y2="25" />
   <line x1="35" y1="25" x2="60" y2="25" />
   <line x1="35" y1="25" x2="60" y2="25" />
   <line x1="35" y1="25" x2="60" y2="25" />
@@ -9419,7 +9411,6 @@ Attributes:
   <line x1="40" y1="30" x2="65" y2="30" />
   <line x1="40" y1="30" x2="65" y2="30" />
   <line x1="40" y1="30" x2="65" y2="30" />
-  <line x1="40" y1="30" x2="65" y2="30" />
   <line x1="40" y1="30" x2="66" y2="30" />
   <line x1="40" y1="30" x2="66" y2="30" />
   <line x1="40" y1="30" x2="66" y2="30" />
@@ -9456,7 +9447,7 @@ Attributes:
   <line x1="40" y1="30" x2="66" y2="30" />
   <line x1="40" y1="30" x2="66" y2="30" />
   <line x1="40" y1="30" x2="66" y2="30" />
-  <line x1="41" y1="31" x2="66" y2="31" />
+  <line x1="40" y1="30" x2="66" y2="30" />
   <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="66" y2="31" />
   <line x1="41" y1="31" x2="66" y2="31" />
@@ -9544,7 +9535,7 @@ Attributes:
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="41" y1="31" x2="67" y2="31" />
-  <line x1="42" y1="32" x2="67" y2="32" />
+  <line x1="41" y1="31" x2="67" y2="31" />
   <line x1="42" y1="32" x2="67" y2="32" />
   <line x1="42" y1="32" x2="67" y2="32" />
   <line x1="42" y1="32" x2="67" y2="32" />
@@ -10123,7 +10114,6 @@ Attributes:
   <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="73" y2="38" />
-  <line x1="48" y1="38" x2="73" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
@@ -10160,7 +10150,7 @@ Attributes:
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="48" y1="38" x2="74" y2="38" />
-  <line x1="49" y1="39" x2="74" y2="39" />
+  <line x1="48" y1="38" x2="74" y2="38" />
   <line x1="49" y1="39" x2="74" y2="39" />
   <line x1="49" y1="39" x2="74" y2="39" />
   <line x1="49" y1="39" x2="74" y2="39" />
@@ -10248,7 +10238,7 @@ Attributes:
   <line x1="49" y1="39" x2="75" y2="39" />
   <line x1="49" y1="39" x2="75" y2="39" />
   <line x1="49" y1="39" x2="75" y2="39" />
-  <line x1="50" y1="40" x2="75" y2="40" />
+  <line x1="49" y1="39" x2="75" y2="39" />
   <line x1="50" y1="40" x2="75" y2="40" />
   <line x1="50" y1="40" x2="75" y2="40" />
   <line x1="50" y1="40" x2="75" y2="40" />
@@ -10563,6 +10553,7 @@ Attributes:
   <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="78" y2="43" />
+  <line x1="53" y1="43" x2="78" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
@@ -10599,7 +10590,7 @@ Attributes:
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
   <line x1="53" y1="43" x2="79" y2="43" />
-  <line x1="53" y1="43" x2="79" y2="43" />
+  <line x1="54" y1="44" x2="79" y2="44" />
   <line x1="54" y1="44" x2="79" y2="44" />
   <line x1="54" y1="44" x2="79" y2="44" />
   <line x1="54" y1="44" x2="79" y2="44" />
@@ -10687,7 +10678,6 @@ Attributes:
   <line x1="54" y1="44" x2="80" y2="44" />
   <line x1="54" y1="44" x2="80" y2="44" />
   <line x1="54" y1="44" x2="80" y2="44" />
-  <line x1="54" y1="44" x2="80" y2="44" />
   <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="80" y2="45" />
@@ -10739,7 +10729,7 @@ Attributes:
   <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="80" y2="45" />
-  <line x1="55" y1="45" x2="81" y2="45" />
+  <line x1="55" y1="45" x2="80" y2="45" />
   <line x1="55" y1="45" x2="81" y2="45" />
   <line x1="55" y1="45" x2="81" y2="45" />
   <line x1="55" y1="45" x2="81" y2="45" />
@@ -11039,7 +11029,7 @@ Attributes:
   <line x1="58" y1="48" x2="84" y2="48" />
   <line x1="58" y1="48" x2="84" y2="48" />
   <line x1="58" y1="48" x2="84" y2="48" />
-  <line x1="58" y1="48" x2="84" y2="48" />
+  <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
   <line x1="59" y1="49" x2="84" y2="49" />
@@ -11127,7 +11117,7 @@ Attributes:
   <line x1="59" y1="49" x2="85" y2="49" />
   <line x1="59" y1="49" x2="85" y2="49" />
   <line x1="59" y1="49" x2="85" y2="49" />
-  <line x1="59" y1="49" x2="85" y2="49" />
+  <line x1="60" y1="50" x2="85" y2="50" />
   <line x1="60" y1="50" x2="85" y2="50" />
   <line x1="60" y1="50" x2="85" y2="50" />
   <line x1="60" y1="50" x2="85" y2="50" />
@@ -11215,7 +11205,7 @@ Attributes:
   <line x1="60" y1="50" x2="86" y2="50" />
   <line x1="60" y1="50" x2="86" y2="50" />
   <line x1="60" y1="50" x2="86" y2="50" />
-  <line x1="60" y1="50" x2="86" y2="50" />
+  <line x1="61" y1="51" x2="86" y2="51" />
   <line x1="61" y1="51" x2="86" y2="51" />
   <line x1="61" y1="51" x2="86" y2="51" />
   <line x1="61" y1="51" x2="86" y2="51" />
@@ -11530,7 +11520,6 @@ Attributes:
   <line x1="64" y1="54" x2="89" y2="54" />
   <line x1="64" y1="54" x2="89" y2="54" />
   <line x1="64" y1="54" x2="89" y2="54" />
-  <line x1="64" y1="54" x2="89" y2="54" />
   <line x1="64" y1="54" x2="90" y2="54" />
   <line x1="64" y1="54" x2="90" y2="54" />
   <line x1="64" y1="54" x2="90" y2="54" />
@@ -11567,7 +11556,7 @@ Attributes:
   <line x1="64" y1="54" x2="90" y2="54" />
   <line x1="64" y1="54" x2="90" y2="54" />
   <line x1="64" y1="54" x2="90" y2="54" />
-  <line x1="65" y1="55" x2="90" y2="55" />
+  <line x1="64" y1="54" x2="90" y2="54" />
   <line x1="65" y1="55" x2="90" y2="55" />
   <line x1="65" y1="55" x2="90" y2="55" />
   <line x1="65" y1="55" x2="90" y2="55" />
@@ -11655,7 +11644,7 @@ Attributes:
   <line x1="65" y1="55" x2="91" y2="55" />
   <line x1="65" y1="55" x2="91" y2="55" />
   <line x1="65" y1="55" x2="91" y2="55" />
-  <line x1="66" y1="56" x2="91" y2="56" />
+  <line x1="65" y1="55" x2="91" y2="55" />
   <line x1="66" y1="56" x2="91" y2="56" />
   <line x1="66" y1="56" x2="91" y2="56" />
   <line x1="66" y1="56" x2="91" y2="56" />
@@ -12234,7 +12223,6 @@ Attributes:
   <line x1="72" y1="62" x2="97" y2="62" />
   <line x1="72" y1="62" x2="97" y2="62" />
   <line x1="72" y1="62" x2="97" y2="62" />
-  <line x1="72" y1="62" x2="97" y2="62" />
   <line x1="72" y1="62" x2="98" y2="62" />
   <line x1="72" y1="62" x2="98" y2="62" />
   <line x1="72" y1="62" x2="98" y2="62" />
@@ -12271,7 +12259,7 @@ Attributes:
   <line x1="72" y1="62" x2="98" y2="62" />
   <line x1="72" y1="62" x2="98" y2="62" />
   <line x1="72" y1="62" x2="98" y2="62" />
-  <line x1="73" y1="63" x2="98" y2="63" />
+  <line x1="72" y1="62" x2="98" y2="62" />
   <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="98" y2="63" />
   <line x1="73" y1="63" x2="98" y2="63" />
@@ -12359,7 +12347,7 @@ Attributes:
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="73" y1="63" x2="99" y2="63" />
-  <line x1="74" y1="64" x2="99" y2="64" />
+  <line x1="73" y1="63" x2="99" y2="63" />
   <line x1="74" y1="64" x2="99" y2="64" />
   <line x1="74" y1="64" x2="99" y2="64" />
   <line x1="74" y1="64" x2="99" y2="64" />
@@ -12850,7 +12838,7 @@ Attributes:
   <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="104" y2="69" />
-  <line x1="79" y1="69" x2="105" y2="69" />
+  <line x1="79" y1="69" x2="104" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
   <line x1="79" y1="69" x2="105" y2="69" />
@@ -12961,11 +12949,11 @@ Attributes:
   <!-- Text -->
   <text x="93.294544" y="116.000852" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
   <text x="126.000852" y="83.294544" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,126.000852,83.294544)">181</text>
-  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">279405</text>
+  <text x="35.294118" y="80.706734" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,80.706734)">279135</text>
 </svg>
 </td>
 </tr>
-</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-84a2c2f1-1856-4eb8-9147-7610d9be0d72' class='xr-section-summary-in' type='checkbox'  checked><label for='section-84a2c2f1-1856-4eb8-9147-7610d9be0d72' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/07/14 07:17:37</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-29e136ef-2b91-4004-8ee8-66847b9ab27d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-29e136ef-2b91-4004-8ee8-66847b9ab27d' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Anomalies</dd><dt><span>long_title :</span></dt><dd>SubX Anomalies</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/03/24 00:57:06</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
     
 
 

--- a/ua_ECCC-GEM_.climo.p.nc.html
+++ b/ua_ECCC-GEM_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_eccc-gem>subx_hindcast_ua200_daily_climo_eccc-gem</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEM_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/ECCC-GEM</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEM_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-06-19</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 11712)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 27.5 28.5 29.5 30.5 31.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/06/19 17:18:24
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-3b315757-e941-484e-9c7a-22d2463cf475' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3b315757-e941-484e-9c7a-22d2463cf475' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 11712</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-214ea14e-9cbf-4fe4-8208-3c54dffcefa4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-214ea14e-9cbf-4fe4-8208-3c54dffcefa4' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-ce7bb951-5be5-4f1e-a842-670b4874202b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ce7bb951-5be5-4f1e-a842-670b4874202b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2cb9e0b4-2f91-49ed-ba8b-80330b515ebb' class='xr-var-data-in' type='checkbox'><label for='data-2cb9e0b4-2f91-49ed-ba8b-80330b515ebb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-1c14ce5e-5d6d-4c7c-83d3-b7afaca15f8d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1c14ce5e-5d6d-4c7c-83d3-b7afaca15f8d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e9e007fb-7e33-4428-9f2c-4576ee2e9a40' class='xr-var-data-in' type='checkbox'><label for='data-e9e007fb-7e33-4428-9f2c-4576ee2e9a40' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 29.5 30.5 31.5</div><input id='attrs-cffabea3-7d9d-44e1-ad6a-4589abef1ea2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cffabea3-7d9d-44e1-ad6a-4589abef1ea2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ac9cfcd6-f805-4b44-99ee-8bcdcf9ee48f' class='xr-var-data-in' type='checkbox'><label for='data-ac9cfcd6-f805-4b44-99ee-8bcdcf9ee48f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 29.5, 30.5, 31.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-77d60a4b-0493-45ae-b6f8-652ad1d10782' class='xr-section-summary-in' type='checkbox'  checked><label for='section-77d60a4b-0493-45ae-b6f8-652ad1d10782' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-fad1ee26-bc06-4848-b0be-a3a48e7688df' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fad1ee26-bc06-4848-b0be-a3a48e7688df' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-94466f6d-3c3d-4ce4-80b7-c3e9dbb41f1e' class='xr-var-data-in' type='checkbox'><label for='data-94466f6d-3c3d-4ce4-80b7-c3e9dbb41f1e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 3.05 GB </td> <td> 8.34 MB </td></tr>
+    <tr><th> Shape </th><td> (11712, 181, 360) </td> <td> (32, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="162" height="148" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="27" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="27" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="98" />
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,98.204938 10.000000,27.616703" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="41" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="41" y1="0" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 41.535960,0.000000 112.124195,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="98" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+  <line x1="112" y1="70" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 112.124195,70.588235 112.124195,98.204938 80.588235,98.204938" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="96.356215" y="118.204938" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="132.124195" y="84.396587" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,132.124195,84.396587)">181</text>
+  <text x="35.294118" y="82.910821" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,82.910821)">11712</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-1c29abdf-4ef3-4e06-aa59-87369f44f487' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1c29abdf-4ef3-4e06-aa59-87369f44f487' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/06/19 17:18:24</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_ECCC-GEPS5_.climo.p.nc.html
+++ b/ua_ECCC-GEPS5_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_eccc-geps5>subx_hindcast_ua200_daily_climo_eccc-geps5</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEPS5_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/ECCC-GEPS5</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEPS5_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2019-07-04</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 11712)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 27.5 28.5 29.5 30.5 31.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2019/07/04 11:35:48
+    CreatedBy:     jcrowel
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f3784930-dd2c-4d27-bb9f-42c17a62b2b9' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f3784930-dd2c-4d27-bb9f-42c17a62b2b9' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 11712</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-d64fcc78-0b6a-425d-b5e5-5b76d72d1cf8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d64fcc78-0b6a-425d-b5e5-5b76d72d1cf8' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-a204b126-1bb7-454d-a2c6-b20eba45fdb9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a204b126-1bb7-454d-a2c6-b20eba45fdb9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4c1ff7ae-a50c-4c11-a56b-361b9560efaf' class='xr-var-data-in' type='checkbox'><label for='data-4c1ff7ae-a50c-4c11-a56b-361b9560efaf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-22c051c8-6a0f-429a-b8c5-7c420dafee97' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-22c051c8-6a0f-429a-b8c5-7c420dafee97' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ee2f554-88b3-4145-83ae-df3aa83a5829' class='xr-var-data-in' type='checkbox'><label for='data-2ee2f554-88b3-4145-83ae-df3aa83a5829' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 29.5 30.5 31.5</div><input id='attrs-24b37ca3-b66d-443b-8bb5-2a5a2763bbf2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-24b37ca3-b66d-443b-8bb5-2a5a2763bbf2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-db50df76-7772-4a08-bb27-73b92303f046' class='xr-var-data-in' type='checkbox'><label for='data-db50df76-7772-4a08-bb27-73b92303f046' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 29.5, 30.5, 31.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-db21c5a0-10a1-45cf-8f99-62bd33ed8b7d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-db21c5a0-10a1-45cf-8f99-62bd33ed8b7d' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-b30c4c64-c509-4a49-a583-954a39572776' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b30c4c64-c509-4a49-a583-954a39572776' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5cc3618c-cbe6-4f1f-9d97-1205ae310d37' class='xr-var-data-in' type='checkbox'><label for='data-5cc3618c-cbe6-4f1f-9d97-1205ae310d37' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 3.05 GB </td> <td> 8.34 MB </td></tr>
+    <tr><th> Shape </th><td> (11712, 181, 360) </td> <td> (32, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="162" height="148" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="27" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="27" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="98" />
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,98.204938 10.000000,27.616703" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="41" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="41" y1="0" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 41.535960,0.000000 112.124195,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="98" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+  <line x1="112" y1="70" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 112.124195,70.588235 112.124195,98.204938 80.588235,98.204938" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="96.356215" y="118.204938" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="132.124195" y="84.396587" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,132.124195,84.396587)">181</text>
+  <text x="35.294118" y="82.910821" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,82.910821)">11712</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-d8f4b65a-1692-4b23-9218-fb7eeb21096d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d8f4b65a-1692-4b23-9218-fb7eeb21096d' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2019/07/04 11:35:48</dd><dt><span>CreatedBy :</span></dt><dd>jcrowel</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_ECCC-GEPS6_.climo.p.nc.html
+++ b/ua_ECCC-GEPS6_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_eccc-geps6>subx_hindcast_ua200_daily_climo_eccc-geps6</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEPS6_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/ECCC-GEPS6</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEPS6_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2020-06-14</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 11712)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 27.5 28.5 29.5 30.5 31.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2020/06/14 13:18:56
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2af46b70-2d10-4b22-baf3-4f849a5b3c19' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2af46b70-2d10-4b22-baf3-4f849a5b3c19' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 11712</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-c88678e6-b764-43fb-811c-b3abe5693fa5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c88678e6-b764-43fb-811c-b3abe5693fa5' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-d898ed28-31fe-4eeb-8507-82b9d559c13a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d898ed28-31fe-4eeb-8507-82b9d559c13a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-83b569c4-e3fb-4277-a153-c26fd75ec537' class='xr-var-data-in' type='checkbox'><label for='data-83b569c4-e3fb-4277-a153-c26fd75ec537' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-b35bc511-1a6b-43b1-b850-53df545469bb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b35bc511-1a6b-43b1-b850-53df545469bb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2d1d0e48-ce08-47bd-ac72-eb45731373b6' class='xr-var-data-in' type='checkbox'><label for='data-2d1d0e48-ce08-47bd-ac72-eb45731373b6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 29.5 30.5 31.5</div><input id='attrs-2d3f3048-0c88-4a7b-be4f-14f57910fd66' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2d3f3048-0c88-4a7b-be4f-14f57910fd66' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-76f48176-bf8c-4022-aabb-a26ef798df75' class='xr-var-data-in' type='checkbox'><label for='data-76f48176-bf8c-4022-aabb-a26ef798df75' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 29.5, 30.5, 31.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-98271cd8-46a8-45ed-87d2-45586011527e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-98271cd8-46a8-45ed-87d2-45586011527e' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-650f8842-ffbd-49af-be5d-12af248ba692' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-650f8842-ffbd-49af-be5d-12af248ba692' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c69913a6-607a-42e8-a8c6-02bf2d88ef7c' class='xr-var-data-in' type='checkbox'><label for='data-c69913a6-607a-42e8-a8c6-02bf2d88ef7c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 3.05 GB </td> <td> 8.34 MB </td></tr>
+    <tr><th> Shape </th><td> (11712, 181, 360) </td> <td> (32, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="162" height="148" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="27" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="27" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="98" />
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,98.204938 10.000000,27.616703" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="41" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="41" y1="0" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 41.535960,0.000000 112.124195,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="98" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+  <line x1="112" y1="70" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 112.124195,70.588235 112.124195,98.204938 80.588235,98.204938" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="96.356215" y="118.204938" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="132.124195" y="84.396587" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,132.124195,84.396587)">181</text>
+  <text x="35.294118" y="82.910821" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,82.910821)">11712</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-a7b7365e-daed-4e80-ad89-e366b93a0314' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a7b7365e-daed-4e80-ad89-e366b93a0314' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2020/06/14 13:18:56</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_ECCC-GEPS_.climo.p.nc.html
+++ b/ua_ECCC-GEPS_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_eccc-geps>subx_hindcast_ua200_daily_climo_eccc-geps</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEPS_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/ECCC-GEPS</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ECCC-GEPS_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-11-18</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 11712)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 27.5 28.5 29.5 30.5 31.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/11/18 18:17:51
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-26b315fb-7019-406a-8502-c71376cd4508' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-26b315fb-7019-406a-8502-c71376cd4508' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 11712</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-7ab2faf4-fea8-4c1a-9df6-21a6cfba3f37' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7ab2faf4-fea8-4c1a-9df6-21a6cfba3f37' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-8dc5285c-d7cc-4755-964e-91583eee65ac' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8dc5285c-d7cc-4755-964e-91583eee65ac' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-92a4757b-ed64-4c44-916c-e5817df37190' class='xr-var-data-in' type='checkbox'><label for='data-92a4757b-ed64-4c44-916c-e5817df37190' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-2351a25c-fc19-43b5-9f0a-dc3623ff5e1c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2351a25c-fc19-43b5-9f0a-dc3623ff5e1c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-05b9a09b-1e31-453d-a209-2c880df99399' class='xr-var-data-in' type='checkbox'><label for='data-05b9a09b-1e31-453d-a209-2c880df99399' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 29.5 30.5 31.5</div><input id='attrs-fd555335-60ff-4dab-866d-7fef4dc7a520' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fd555335-60ff-4dab-866d-7fef4dc7a520' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-97b9873d-3769-4440-9e86-0c1b99c283b8' class='xr-var-data-in' type='checkbox'><label for='data-97b9873d-3769-4440-9e86-0c1b99c283b8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 29.5, 30.5, 31.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a7c1624d-65ed-4954-aff3-638718d708f0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a7c1624d-65ed-4954-aff3-638718d708f0' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-244da7a6-9138-42a7-885c-753f256a53fc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-244da7a6-9138-42a7-885c-753f256a53fc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8148f185-c599-4bce-811d-feb2a65b6811' class='xr-var-data-in' type='checkbox'><label for='data-8148f185-c599-4bce-811d-feb2a65b6811' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 3.05 GB </td> <td> 8.34 MB </td></tr>
+    <tr><th> Shape </th><td> (11712, 181, 360) </td> <td> (32, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="162" height="148" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="27" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="27" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="98" />
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,98.204938 10.000000,27.616703" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="41" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="41" y1="0" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 41.535960,0.000000 112.124195,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="98" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+  <line x1="112" y1="70" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 112.124195,70.588235 112.124195,98.204938 80.588235,98.204938" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="96.356215" y="118.204938" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="132.124195" y="84.396587" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,132.124195,84.396587)">181</text>
+  <text x="35.294118" y="82.910821" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,82.910821)">11712</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-00a6cb00-62f7-4512-861e-6fc7e31966df' class='xr-section-summary-in' type='checkbox'  checked><label for='section-00a6cb00-62f7-4512-861e-6fc7e31966df' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/11/18 18:17:51</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_EMC-GEFS_.climo.p.nc.html
+++ b/ua_EMC-GEFS_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_emc-gefs>subx_hindcast_ua200_daily_climo_emc-gefs</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_EMC-GEFS_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/EMC-GEFS</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_EMC-GEFS_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-02-02</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 12810)
+Coordinates:
+  * lat      (lat) float32 90.0 89.0 88.0 87.0 86.0 ... -87.0 -88.0 -89.0 -90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 30.5 31.5 32.5 33.5 34.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(35, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/02/02 10:12:05
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-e884c20c-3c52-48b0-96bf-3462e9382e16' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-e884c20c-3c52-48b0-96bf-3462e9382e16' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 12810</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-3a63f8b4-161b-4d1a-beb5-6931901e11e2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-3a63f8b4-161b-4d1a-beb5-6931901e11e2' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>90.0 89.0 88.0 ... -89.0 -90.0</div><input id='attrs-cb4c4033-2cd9-4f05-b533-e2ee6c71d081' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cb4c4033-2cd9-4f05-b533-e2ee6c71d081' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0d913325-2a4e-4579-b0c6-edd92c47fd87' class='xr-var-data-in' type='checkbox'><label for='data-0d913325-2a4e-4579-b0c6-edd92c47fd87' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([ 90.,  89.,  88.,  87.,  86.,  85.,  84.,  83.,  82.,  81.,  80.,  79.,
+        78.,  77.,  76.,  75.,  74.,  73.,  72.,  71.,  70.,  69.,  68.,  67.,
+        66.,  65.,  64.,  63.,  62.,  61.,  60.,  59.,  58.,  57.,  56.,  55.,
+        54.,  53.,  52.,  51.,  50.,  49.,  48.,  47.,  46.,  45.,  44.,  43.,
+        42.,  41.,  40.,  39.,  38.,  37.,  36.,  35.,  34.,  33.,  32.,  31.,
+        30.,  29.,  28.,  27.,  26.,  25.,  24.,  23.,  22.,  21.,  20.,  19.,
+        18.,  17.,  16.,  15.,  14.,  13.,  12.,  11.,  10.,   9.,   8.,   7.,
+         6.,   5.,   4.,   3.,   2.,   1.,   0.,  -1.,  -2.,  -3.,  -4.,  -5.,
+        -6.,  -7.,  -8.,  -9., -10., -11., -12., -13., -14., -15., -16., -17.,
+       -18., -19., -20., -21., -22., -23., -24., -25., -26., -27., -28., -29.,
+       -30., -31., -32., -33., -34., -35., -36., -37., -38., -39., -40., -41.,
+       -42., -43., -44., -45., -46., -47., -48., -49., -50., -51., -52., -53.,
+       -54., -55., -56., -57., -58., -59., -60., -61., -62., -63., -64., -65.,
+       -66., -67., -68., -69., -70., -71., -72., -73., -74., -75., -76., -77.,
+       -78., -79., -80., -81., -82., -83., -84., -85., -86., -87., -88., -89.,
+       -90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-164a7117-520b-4fd0-ac09-ade661557884' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-164a7117-520b-4fd0-ac09-ade661557884' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-72c00ced-7d84-47ff-b996-8be78076961b' class='xr-var-data-in' type='checkbox'><label for='data-72c00ced-7d84-47ff-b996-8be78076961b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 32.5 33.5 34.5</div><input id='attrs-2c83d4bc-859b-4ea7-a467-6c867156e34b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2c83d4bc-859b-4ea7-a467-6c867156e34b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ffae0f35-e078-4d40-aabe-da7ca53ec284' class='xr-var-data-in' type='checkbox'><label for='data-ffae0f35-e078-4d40-aabe-da7ca53ec284' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 32.5, 33.5, 34.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e101909a-1705-4ea1-971c-ef72d6a8d3be' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e101909a-1705-4ea1-971c-ef72d6a8d3be' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(35, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-1a1ebbc1-5881-4407-986e-4d4b077f986d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1a1ebbc1-5881-4407-986e-4d4b077f986d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b2a4bc5e-f686-404e-ad8d-6df7f2afd6a3' class='xr-var-data-in' type='checkbox'><label for='data-b2a4bc5e-f686-404e-ad8d-6df7f2afd6a3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 3.34 GB </td> <td> 9.12 MB </td></tr>
+    <tr><th> Shape </th><td> (12810, 181, 360) </td> <td> (35, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="161" height="147" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="27" x2="80" y2="97" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="27" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,97.731854 10.000000,27.143619" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="41" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="41" y1="0" x2="111" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 41.000913,0.000000 111.589148,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="111" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="97" x2="111" y2="97" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="97" style="stroke-width:2" />
+  <line x1="111" y1="70" x2="111" y2="97" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 111.589148,70.588235 111.589148,97.731854 80.588235,97.731854" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="96.088692" y="117.731854" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="131.589148" y="84.160045" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,131.589148,84.160045)">181</text>
+  <text x="35.294118" y="82.437737" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,82.437737)">12810</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-95e1b2f5-e723-4239-bb89-edc56fe08039' class='xr-section-summary-in' type='checkbox'  checked><label for='section-95e1b2f5-e723-4239-bb89-edc56fe08039' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/02/02 10:12:05</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_ESRL-FIMr1p1_.climo.p.nc.html
+++ b/ua_ESRL-FIMr1p1_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_esrl-fimr1p1>subx_hindcast_ua200_daily_climo_esrl-fimr1p1</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ESRL-FIMr1p1_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/ESRL-FIMr1p1</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_ESRL-FIMr1p1_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-02-03</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 11712)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 27.5 28.5 29.5 30.5 31.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/02/03 14:06:31
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-20ff82fa-926a-4978-b68b-6c6753240a56' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-20ff82fa-926a-4978-b68b-6c6753240a56' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 11712</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b63fa701-b5b4-4253-b423-c50d8e305616' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b63fa701-b5b4-4253-b423-c50d8e305616' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-c084a146-9f36-4858-b406-eec9c2ebabb5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c084a146-9f36-4858-b406-eec9c2ebabb5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5b856904-4f80-4a42-acb3-b75711e58389' class='xr-var-data-in' type='checkbox'><label for='data-5b856904-4f80-4a42-acb3-b75711e58389' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-39548083-0f3f-46ff-9f97-e579ba94fd69' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-39548083-0f3f-46ff-9f97-e579ba94fd69' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0aa26d76-da8f-48c3-85b2-1d5ccee6dc17' class='xr-var-data-in' type='checkbox'><label for='data-0aa26d76-da8f-48c3-85b2-1d5ccee6dc17' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 29.5 30.5 31.5</div><input id='attrs-8a7e99f5-64b9-44c7-b8aa-3558c5cfc4f4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8a7e99f5-64b9-44c7-b8aa-3558c5cfc4f4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-30d2f7c1-ebe5-40db-ad3b-7f053540460f' class='xr-var-data-in' type='checkbox'><label for='data-30d2f7c1-ebe5-40db-ad3b-7f053540460f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 29.5, 30.5, 31.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-50167efc-957e-463c-99e7-75acaaf3de90' class='xr-section-summary-in' type='checkbox'  checked><label for='section-50167efc-957e-463c-99e7-75acaaf3de90' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(32, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-0f924ad3-afcf-4609-8961-1cd60e717b9e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0f924ad3-afcf-4609-8961-1cd60e717b9e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b1b743e5-5ff0-4ca3-b056-f14948db5d8a' class='xr-var-data-in' type='checkbox'><label for='data-b1b743e5-5ff0-4ca3-b056-f14948db5d8a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 3.05 GB </td> <td> 8.34 MB </td></tr>
+    <tr><th> Shape </th><td> (11712, 181, 360) </td> <td> (32, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="162" height="148" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="27" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="27" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="27" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="10" y1="0" x2="10" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="28" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="11" y1="1" x2="11" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="29" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="12" y1="2" x2="12" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="30" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="13" y1="3" x2="13" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="31" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="14" y1="4" x2="14" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="32" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="15" y1="5" x2="15" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="33" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="16" y1="6" x2="16" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="34" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="17" y1="7" x2="17" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="35" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="18" y1="8" x2="18" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="36" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="19" y1="9" x2="19" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="37" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="20" y1="10" x2="20" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="38" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="21" y1="11" x2="21" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="39" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="22" y1="12" x2="22" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="40" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="23" y1="13" x2="23" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="41" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="24" y1="14" x2="24" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="42" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="25" y1="15" x2="25" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="43" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="26" y1="16" x2="26" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="44" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="27" y1="17" x2="27" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="45" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="28" y1="18" x2="28" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="46" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="29" y1="19" x2="29" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="47" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="30" y1="20" x2="30" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="48" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="31" y1="21" x2="31" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="49" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="32" y1="22" x2="32" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="50" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="33" y1="23" x2="33" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="51" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="34" y1="24" x2="34" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="52" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="35" y1="25" x2="35" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="53" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="36" y1="26" x2="36" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="54" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="37" y1="27" x2="37" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="55" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="38" y1="28" x2="38" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="56" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="39" y1="29" x2="39" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="57" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="40" y1="30" x2="40" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="58" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="41" y1="31" x2="41" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="59" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="42" y1="32" x2="42" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="60" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="43" y1="33" x2="43" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="61" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="44" y1="34" x2="44" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="62" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="45" y1="35" x2="45" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="63" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="46" y1="36" x2="46" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="64" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="47" y1="37" x2="47" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="65" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="48" y1="38" x2="48" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="66" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="49" y1="39" x2="49" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="67" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="50" y1="40" x2="50" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="68" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="51" y1="41" x2="51" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="69" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="52" y1="42" x2="52" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="70" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="53" y1="43" x2="53" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="71" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="54" y1="44" x2="54" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="72" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="55" y1="45" x2="55" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="73" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="56" y1="46" x2="56" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="74" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="57" y1="47" x2="57" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="75" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="58" y1="48" x2="58" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="76" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="59" y1="49" x2="59" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="77" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="60" y1="50" x2="60" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="78" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="61" y1="51" x2="61" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="79" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="62" y1="52" x2="62" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="80" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="63" y1="53" x2="63" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="81" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="64" y1="54" x2="64" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="82" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="65" y1="55" x2="65" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="83" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="66" y1="56" x2="66" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="84" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="67" y1="57" x2="67" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="85" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="68" y1="58" x2="68" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="86" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="69" y1="59" x2="69" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="87" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="70" y1="60" x2="70" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="88" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="71" y1="61" x2="71" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="89" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="72" y1="62" x2="72" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="90" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="73" y1="63" x2="73" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="91" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="74" y1="64" x2="74" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="92" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="75" y1="65" x2="75" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="93" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="76" y1="66" x2="76" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="94" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="77" y1="67" x2="77" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="95" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="78" y1="68" x2="78" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="96" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="79" y1="69" x2="79" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="97" />
+  <line x1="80" y1="70" x2="80" y2="98" />
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,98.204938 10.000000,27.616703" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="41" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="41" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="10" y1="0" x2="42" y2="0" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="42" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="11" y1="1" x2="43" y2="1" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="43" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="12" y1="2" x2="44" y2="2" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="44" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="13" y1="3" x2="45" y2="3" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="45" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="14" y1="4" x2="46" y2="4" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="46" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="15" y1="5" x2="47" y2="5" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="47" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="16" y1="6" x2="48" y2="6" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="48" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="17" y1="7" x2="49" y2="7" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="49" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="18" y1="8" x2="50" y2="8" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="50" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="19" y1="9" x2="51" y2="9" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="51" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="20" y1="10" x2="52" y2="10" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="52" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="21" y1="11" x2="53" y2="11" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="53" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="22" y1="12" x2="54" y2="12" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="54" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="23" y1="13" x2="55" y2="13" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="55" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="24" y1="14" x2="56" y2="14" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="56" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="25" y1="15" x2="57" y2="15" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="57" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="26" y1="16" x2="58" y2="16" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="58" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="27" y1="17" x2="59" y2="17" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="59" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="28" y1="18" x2="60" y2="18" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="60" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="29" y1="19" x2="61" y2="19" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="61" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="30" y1="20" x2="62" y2="20" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="62" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="31" y1="21" x2="63" y2="21" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="63" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="32" y1="22" x2="64" y2="22" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="64" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="33" y1="23" x2="65" y2="23" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="65" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="34" y1="24" x2="66" y2="24" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="66" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="35" y1="25" x2="67" y2="25" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="67" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="36" y1="26" x2="68" y2="26" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="68" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="37" y1="27" x2="69" y2="27" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="69" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="38" y1="28" x2="70" y2="28" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="70" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="39" y1="29" x2="71" y2="29" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="71" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="40" y1="30" x2="72" y2="30" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="72" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="41" y1="31" x2="73" y2="31" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="73" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="42" y1="32" x2="74" y2="32" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="74" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="43" y1="33" x2="75" y2="33" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="75" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="44" y1="34" x2="76" y2="34" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="76" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="45" y1="35" x2="77" y2="35" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="77" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="46" y1="36" x2="78" y2="36" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="78" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="47" y1="37" x2="79" y2="37" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="79" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="48" y1="38" x2="80" y2="38" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="80" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="49" y1="39" x2="81" y2="39" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="81" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="50" y1="40" x2="82" y2="40" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="82" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="51" y1="41" x2="83" y2="41" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="83" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="52" y1="42" x2="84" y2="42" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="84" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="53" y1="43" x2="85" y2="43" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="85" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="54" y1="44" x2="86" y2="44" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="86" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="55" y1="45" x2="87" y2="45" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="87" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="56" y1="46" x2="88" y2="46" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="88" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="57" y1="47" x2="89" y2="47" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="89" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="58" y1="48" x2="90" y2="48" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="90" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="59" y1="49" x2="91" y2="49" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="91" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="60" y1="50" x2="92" y2="50" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="92" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="61" y1="51" x2="93" y2="51" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="93" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="62" y1="52" x2="94" y2="52" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="94" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="63" y1="53" x2="95" y2="53" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="95" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="64" y1="54" x2="96" y2="54" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="96" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="65" y1="55" x2="97" y2="55" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="97" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="66" y1="56" x2="98" y2="56" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="98" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="67" y1="57" x2="99" y2="57" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="99" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="68" y1="58" x2="100" y2="58" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="100" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="69" y1="59" x2="101" y2="59" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="101" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="70" y1="60" x2="102" y2="60" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="102" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="71" y1="61" x2="103" y2="61" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="103" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="72" y1="62" x2="104" y2="62" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="104" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="73" y1="63" x2="105" y2="63" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="105" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="74" y1="64" x2="106" y2="64" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="106" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="75" y1="65" x2="107" y2="65" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="107" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="76" y1="66" x2="108" y2="66" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="108" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="77" y1="67" x2="109" y2="67" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="109" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="78" y1="68" x2="110" y2="68" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="110" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="79" y1="69" x2="111" y2="69" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="111" y2="70" />
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="41" y1="0" x2="112" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 41.535960,0.000000 112.124195,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="112" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="98" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="98" style="stroke-width:2" />
+  <line x1="112" y1="70" x2="112" y2="98" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 112.124195,70.588235 112.124195,98.204938 80.588235,98.204938" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="96.356215" y="118.204938" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="132.124195" y="84.396587" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,132.124195,84.396587)">181</text>
+  <text x="35.294118" y="82.910821" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,82.910821)">11712</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-5ba95ae7-6d34-431d-95be-f16eda70c9af' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5ba95ae7-6d34-431d-95be-f16eda70c9af' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/02/03 14:06:31</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_GMAO-GEOS_V2p1_.climo.p.nc.html
+++ b/ua_GMAO-GEOS_V2p1_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_gmao-geos_v2p1>subx_hindcast_ua200_daily_climo_gmao-geos_v2p1</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_GMAO-GEOS_V2p1_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/GMAO-GEOS_V2p1</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_GMAO-GEOS_V2p1_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-02-21</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 16470)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 40.5 41.5 42.5 43.5 44.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/02/21 21:08:52
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-92b5ee25-10dd-4320-8d46-7182cb70b5b4' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-92b5ee25-10dd-4320-8d46-7182cb70b5b4' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 16470</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-23654964-127d-48f2-88c0-26721eff89bf' class='xr-section-summary-in' type='checkbox'  checked><label for='section-23654964-127d-48f2-88c0-26721eff89bf' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-f834e604-1a03-4e7d-bc30-5ddb1a62abd3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f834e604-1a03-4e7d-bc30-5ddb1a62abd3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13c253f2-650f-4296-b206-6ce2113a832b' class='xr-var-data-in' type='checkbox'><label for='data-13c253f2-650f-4296-b206-6ce2113a832b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-81c5808e-0eb3-4391-b9ad-d0b07d5d8a64' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-81c5808e-0eb3-4391-b9ad-d0b07d5d8a64' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-641a2a01-3686-4ede-bff8-87b422bfaa0f' class='xr-var-data-in' type='checkbox'><label for='data-641a2a01-3686-4ede-bff8-87b422bfaa0f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-5cf44bff-0771-4300-95aa-8fb633f6a994' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5cf44bff-0771-4300-95aa-8fb633f6a994' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3ab37a21-129b-47ba-b148-aed41a40b6d3' class='xr-var-data-in' type='checkbox'><label for='data-3ab37a21-129b-47ba-b148-aed41a40b6d3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-624762be-6320-4f1d-9107-12684ace568b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-624762be-6320-4f1d-9107-12684ace568b' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-faef28ac-9e89-4a51-8f1e-4257e22525ac' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-faef28ac-9e89-4a51-8f1e-4257e22525ac' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1429aae2-de57-4a33-b2ee-a8c8a3c9eaf6' class='xr-var-data-in' type='checkbox'><label for='data-1429aae2-de57-4a33-b2ee-a8c8a3c9eaf6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 4.29 GB </td> <td> 11.73 MB </td></tr>
+    <tr><th> Shape </th><td> (16470, 181, 360) </td> <td> (45, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="160" height="146" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="25" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="25" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="96" />
+  <line x1="80" y1="70" x2="80" y2="96" />
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,96.458380 10.000000,25.870145" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="39" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="39" y2="0" />
+  <line x1="10" y1="0" x2="39" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="11" y1="1" x2="40" y2="1" />
+  <line x1="11" y1="1" x2="40" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="12" y1="2" x2="41" y2="2" />
+  <line x1="12" y1="2" x2="41" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="13" y1="3" x2="42" y2="3" />
+  <line x1="13" y1="3" x2="42" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="44" y2="4" />
+  <line x1="14" y1="4" x2="44" y2="4" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="16" y1="6" x2="45" y2="6" />
+  <line x1="16" y1="6" x2="45" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="17" y1="7" x2="46" y2="7" />
+  <line x1="17" y1="7" x2="46" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="18" y1="8" x2="47" y2="8" />
+  <line x1="18" y1="8" x2="47" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="49" y2="9" />
+  <line x1="19" y1="9" x2="49" y2="9" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="21" y1="11" x2="50" y2="11" />
+  <line x1="21" y1="11" x2="50" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="22" y1="12" x2="51" y2="12" />
+  <line x1="22" y1="12" x2="51" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="23" y1="13" x2="52" y2="13" />
+  <line x1="23" y1="13" x2="52" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="54" y2="14" />
+  <line x1="24" y1="14" x2="54" y2="14" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="55" y2="15" />
+  <line x1="25" y1="15" x2="55" y2="15" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="27" y1="17" x2="56" y2="17" />
+  <line x1="27" y1="17" x2="56" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="28" y1="18" x2="57" y2="18" />
+  <line x1="28" y1="18" x2="57" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="29" y1="19" x2="58" y2="19" />
+  <line x1="29" y1="19" x2="58" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="60" y2="20" />
+  <line x1="30" y1="20" x2="60" y2="20" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="32" y1="22" x2="61" y2="22" />
+  <line x1="32" y1="22" x2="61" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="33" y1="23" x2="62" y2="23" />
+  <line x1="33" y1="23" x2="62" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="34" y1="24" x2="63" y2="24" />
+  <line x1="34" y1="24" x2="63" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="65" y2="25" />
+  <line x1="35" y1="25" x2="65" y2="25" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="66" y2="26" />
+  <line x1="36" y1="26" x2="66" y2="26" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="38" y1="28" x2="67" y2="28" />
+  <line x1="38" y1="28" x2="67" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="39" y1="29" x2="68" y2="29" />
+  <line x1="39" y1="29" x2="68" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="40" y1="30" x2="69" y2="30" />
+  <line x1="40" y1="30" x2="69" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="71" y2="31" />
+  <line x1="41" y1="31" x2="71" y2="31" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="43" y1="33" x2="72" y2="33" />
+  <line x1="43" y1="33" x2="72" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="44" y1="34" x2="73" y2="34" />
+  <line x1="44" y1="34" x2="73" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="45" y1="35" x2="74" y2="35" />
+  <line x1="45" y1="35" x2="74" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="76" y2="36" />
+  <line x1="46" y1="36" x2="76" y2="36" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="48" y1="38" x2="77" y2="38" />
+  <line x1="48" y1="38" x2="77" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="49" y1="39" x2="78" y2="39" />
+  <line x1="49" y1="39" x2="78" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="50" y1="40" x2="79" y2="40" />
+  <line x1="50" y1="40" x2="79" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="51" y1="41" x2="80" y2="41" />
+  <line x1="51" y1="41" x2="80" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="82" y2="42" />
+  <line x1="52" y1="42" x2="82" y2="42" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="54" y1="44" x2="83" y2="44" />
+  <line x1="54" y1="44" x2="83" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="55" y1="45" x2="84" y2="45" />
+  <line x1="55" y1="45" x2="84" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="56" y1="46" x2="85" y2="46" />
+  <line x1="56" y1="46" x2="85" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="87" y2="47" />
+  <line x1="57" y1="47" x2="87" y2="47" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="59" y1="49" x2="88" y2="49" />
+  <line x1="59" y1="49" x2="88" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="60" y1="50" x2="89" y2="50" />
+  <line x1="60" y1="50" x2="89" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="61" y1="51" x2="90" y2="51" />
+  <line x1="61" y1="51" x2="90" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="92" y2="52" />
+  <line x1="62" y1="52" x2="92" y2="52" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="93" y2="53" />
+  <line x1="63" y1="53" x2="93" y2="53" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="65" y1="55" x2="94" y2="55" />
+  <line x1="65" y1="55" x2="94" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="66" y1="56" x2="95" y2="56" />
+  <line x1="66" y1="56" x2="95" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="67" y1="57" x2="96" y2="57" />
+  <line x1="67" y1="57" x2="96" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="98" y2="58" />
+  <line x1="68" y1="58" x2="98" y2="58" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="70" y1="60" x2="99" y2="60" />
+  <line x1="70" y1="60" x2="99" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="71" y1="61" x2="100" y2="61" />
+  <line x1="71" y1="61" x2="100" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="72" y1="62" x2="101" y2="62" />
+  <line x1="72" y1="62" x2="101" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="103" y2="63" />
+  <line x1="73" y1="63" x2="103" y2="63" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="75" y1="65" x2="104" y2="65" />
+  <line x1="75" y1="65" x2="104" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="76" y1="66" x2="105" y2="66" />
+  <line x1="76" y1="66" x2="105" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="77" y1="67" x2="106" y2="67" />
+  <line x1="77" y1="67" x2="106" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="78" y1="68" x2="107" y2="68" />
+  <line x1="78" y1="68" x2="107" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="109" y2="69" />
+  <line x1="79" y1="69" x2="109" y2="69" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="110" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="39" y1="0" x2="110" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 39.534638,0.000000 110.122874,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="110" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="96" x2="110" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+  <line x1="110" y1="70" x2="110" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 110.122874,70.588235 110.122874,96.458380 80.588235,96.458380" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="95.355554" y="116.458380" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="130.122874" y="83.523308" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,130.122874,83.523308)">181</text>
+  <text x="35.294118" y="81.164263" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,81.164263)">16470</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-132809b6-e0fb-4f2b-9591-22d2fdee4213' class='xr-section-summary-in' type='checkbox'  checked><label for='section-132809b6-e0fb-4f2b-9591-22d2fdee4213' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/02/21 21:08:52</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_NRL-NESM_.climo.p.nc.html
+++ b/ua_NRL-NESM_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_nrl-nesm>subx_hindcast_ua200_daily_climo_nrl-nesm</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_NRL-NESM_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/NRL-NESM</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_NRL-NESM_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-02-21</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 16470)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 40.5 41.5 42.5 43.5 44.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/02/21 20:09:31
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-7ade22a3-ab3c-47cc-9798-c10bbda02b33' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7ade22a3-ab3c-47cc-9798-c10bbda02b33' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 16470</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-38240c69-ad0f-4be0-8ad5-ba5e7e95e948' class='xr-section-summary-in' type='checkbox'  checked><label for='section-38240c69-ad0f-4be0-8ad5-ba5e7e95e948' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-4fabf8aa-69e5-4b21-a453-debcd9c4f4b0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4fabf8aa-69e5-4b21-a453-debcd9c4f4b0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3b8c1e58-a0a9-42aa-b677-944ec8f51ff2' class='xr-var-data-in' type='checkbox'><label for='data-3b8c1e58-a0a9-42aa-b677-944ec8f51ff2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-b20103f4-27fb-4140-8642-cbff8df3871f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b20103f4-27fb-4140-8642-cbff8df3871f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e1fde0a1-073f-40cf-920a-f88572c84e41' class='xr-var-data-in' type='checkbox'><label for='data-e1fde0a1-073f-40cf-920a-f88572c84e41' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-29094207-0f23-420d-ac70-909f8260f6dc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-29094207-0f23-420d-ac70-909f8260f6dc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-390a4ff0-ce52-4bc4-8e71-be388060276f' class='xr-var-data-in' type='checkbox'><label for='data-390a4ff0-ce52-4bc4-8e71-be388060276f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7e9800a2-64f5-4abe-b9f2-69568d87a6ca' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7e9800a2-64f5-4abe-b9f2-69568d87a6ca' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-2118fd4b-487d-4b2e-a7bd-1bfdb473e58a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2118fd4b-487d-4b2e-a7bd-1bfdb473e58a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c7ae3245-ab26-44c8-8912-dabec3098559' class='xr-var-data-in' type='checkbox'><label for='data-c7ae3245-ab26-44c8-8912-dabec3098559' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 4.29 GB </td> <td> 11.73 MB </td></tr>
+    <tr><th> Shape </th><td> (16470, 181, 360) </td> <td> (45, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="160" height="146" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="25" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="25" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="96" />
+  <line x1="80" y1="70" x2="80" y2="96" />
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,96.458380 10.000000,25.870145" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="39" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="39" y2="0" />
+  <line x1="10" y1="0" x2="39" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="11" y1="1" x2="40" y2="1" />
+  <line x1="11" y1="1" x2="40" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="12" y1="2" x2="41" y2="2" />
+  <line x1="12" y1="2" x2="41" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="13" y1="3" x2="42" y2="3" />
+  <line x1="13" y1="3" x2="42" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="44" y2="4" />
+  <line x1="14" y1="4" x2="44" y2="4" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="16" y1="6" x2="45" y2="6" />
+  <line x1="16" y1="6" x2="45" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="17" y1="7" x2="46" y2="7" />
+  <line x1="17" y1="7" x2="46" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="18" y1="8" x2="47" y2="8" />
+  <line x1="18" y1="8" x2="47" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="49" y2="9" />
+  <line x1="19" y1="9" x2="49" y2="9" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="21" y1="11" x2="50" y2="11" />
+  <line x1="21" y1="11" x2="50" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="22" y1="12" x2="51" y2="12" />
+  <line x1="22" y1="12" x2="51" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="23" y1="13" x2="52" y2="13" />
+  <line x1="23" y1="13" x2="52" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="54" y2="14" />
+  <line x1="24" y1="14" x2="54" y2="14" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="55" y2="15" />
+  <line x1="25" y1="15" x2="55" y2="15" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="27" y1="17" x2="56" y2="17" />
+  <line x1="27" y1="17" x2="56" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="28" y1="18" x2="57" y2="18" />
+  <line x1="28" y1="18" x2="57" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="29" y1="19" x2="58" y2="19" />
+  <line x1="29" y1="19" x2="58" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="60" y2="20" />
+  <line x1="30" y1="20" x2="60" y2="20" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="32" y1="22" x2="61" y2="22" />
+  <line x1="32" y1="22" x2="61" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="33" y1="23" x2="62" y2="23" />
+  <line x1="33" y1="23" x2="62" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="34" y1="24" x2="63" y2="24" />
+  <line x1="34" y1="24" x2="63" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="65" y2="25" />
+  <line x1="35" y1="25" x2="65" y2="25" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="66" y2="26" />
+  <line x1="36" y1="26" x2="66" y2="26" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="38" y1="28" x2="67" y2="28" />
+  <line x1="38" y1="28" x2="67" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="39" y1="29" x2="68" y2="29" />
+  <line x1="39" y1="29" x2="68" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="40" y1="30" x2="69" y2="30" />
+  <line x1="40" y1="30" x2="69" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="71" y2="31" />
+  <line x1="41" y1="31" x2="71" y2="31" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="43" y1="33" x2="72" y2="33" />
+  <line x1="43" y1="33" x2="72" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="44" y1="34" x2="73" y2="34" />
+  <line x1="44" y1="34" x2="73" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="45" y1="35" x2="74" y2="35" />
+  <line x1="45" y1="35" x2="74" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="76" y2="36" />
+  <line x1="46" y1="36" x2="76" y2="36" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="48" y1="38" x2="77" y2="38" />
+  <line x1="48" y1="38" x2="77" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="49" y1="39" x2="78" y2="39" />
+  <line x1="49" y1="39" x2="78" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="50" y1="40" x2="79" y2="40" />
+  <line x1="50" y1="40" x2="79" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="51" y1="41" x2="80" y2="41" />
+  <line x1="51" y1="41" x2="80" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="82" y2="42" />
+  <line x1="52" y1="42" x2="82" y2="42" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="54" y1="44" x2="83" y2="44" />
+  <line x1="54" y1="44" x2="83" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="55" y1="45" x2="84" y2="45" />
+  <line x1="55" y1="45" x2="84" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="56" y1="46" x2="85" y2="46" />
+  <line x1="56" y1="46" x2="85" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="87" y2="47" />
+  <line x1="57" y1="47" x2="87" y2="47" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="59" y1="49" x2="88" y2="49" />
+  <line x1="59" y1="49" x2="88" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="60" y1="50" x2="89" y2="50" />
+  <line x1="60" y1="50" x2="89" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="61" y1="51" x2="90" y2="51" />
+  <line x1="61" y1="51" x2="90" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="92" y2="52" />
+  <line x1="62" y1="52" x2="92" y2="52" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="93" y2="53" />
+  <line x1="63" y1="53" x2="93" y2="53" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="65" y1="55" x2="94" y2="55" />
+  <line x1="65" y1="55" x2="94" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="66" y1="56" x2="95" y2="56" />
+  <line x1="66" y1="56" x2="95" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="67" y1="57" x2="96" y2="57" />
+  <line x1="67" y1="57" x2="96" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="98" y2="58" />
+  <line x1="68" y1="58" x2="98" y2="58" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="70" y1="60" x2="99" y2="60" />
+  <line x1="70" y1="60" x2="99" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="71" y1="61" x2="100" y2="61" />
+  <line x1="71" y1="61" x2="100" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="72" y1="62" x2="101" y2="62" />
+  <line x1="72" y1="62" x2="101" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="103" y2="63" />
+  <line x1="73" y1="63" x2="103" y2="63" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="75" y1="65" x2="104" y2="65" />
+  <line x1="75" y1="65" x2="104" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="76" y1="66" x2="105" y2="66" />
+  <line x1="76" y1="66" x2="105" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="77" y1="67" x2="106" y2="67" />
+  <line x1="77" y1="67" x2="106" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="78" y1="68" x2="107" y2="68" />
+  <line x1="78" y1="68" x2="107" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="109" y2="69" />
+  <line x1="79" y1="69" x2="109" y2="69" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="110" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="39" y1="0" x2="110" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 39.534638,0.000000 110.122874,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="110" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="96" x2="110" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+  <line x1="110" y1="70" x2="110" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 110.122874,70.588235 110.122874,96.458380 80.588235,96.458380" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="95.355554" y="116.458380" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="130.122874" y="83.523308" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,130.122874,83.523308)">181</text>
+  <text x="35.294118" y="81.164263" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,81.164263)">16470</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-439ac263-8c1a-44ef-b472-0a41cba28676' class='xr-section-summary-in' type='checkbox'  checked><label for='section-439ac263-8c1a-44ef-b472-0a41cba28676' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/02/21 20:09:31</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/ua_RSMAS-CCSM4_.climo.p.nc.html
+++ b/ua_RSMAS-CCSM4_.climo.p.nc.html
@@ -1,0 +1,1296 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SubX Climatology</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
+    <link rel="stylesheet" href="static/pangeo-style.css">
+
+</head>
+<body>
+
+<div id="navbar" class="navbar navbar-inverse navbar-default navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">
+                <span><img src="img/cola.gif"></span>
+                COLA Catalog</a>
+            <span class="navbar-text navbar-version pull-left"><b></b></span>
+        </div>
+        <div class="collapse navbar-collapse nav-collapse">
+            <ul class="nav navbar-nav">
+              <!--  <li><a href="https://medium.com/pangeo">Blog</a></li>
+                <li><a href="https://discourse.pangeo.io">Forum</a></li> -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<main role="main" class="container">
+    <h1>SubX Climatology</h1>
+    <div>
+        <ol class="breadcrumb">
+
+            <li><a href="main">main</a></li>
+            <li><a href="model">model</a></li>
+            
+            <li><a href=subx>subx</a></li>
+
+<li><a href=subx_hindcast>subx_hindcast</a></li>
+
+<li><a href=subx_hindcast_ua200>subx_hindcast_ua200</a></li>
+
+<li><a href=subx_hindcast_ua200_daily>subx_hindcast_ua200_daily</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo>subx_hindcast_ua200_daily_climo</a></li>
+
+<li><a href=subx_hindcast_ua200_daily_climo_rsmas-ccsm4>subx_hindcast_ua200_daily_climo_rsmas-ccsm4</a></li>
+
+
+            <li class="active">SubX Climatology</li>
+
+        </ol>
+    </div>
+
+    <div class="info">
+         <!-- <h2></h2> -->
+
+        <h3>Load in Python</h3>
+        <pre><code class="language-python">from intake import open_catalog<br>
+cat = open_catalog("https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_RSMAS-CCSM4_climo.p.yaml")
+ds=cat.netcdf.read()</code></pre>
+
+        <h3>Metadata</h3>
+        <table class="table table-condensed table-hover">
+            <tbody>
+
+            <tr>
+                <td>title</td>
+                <td>SubX Climatology</td>
+            </tr>
+
+            <tr>
+                <td>location</td>
+                <td>/shared/subx/hindcast/ua200/daily/climo/RSMAS-CCSM4</td>
+            </tr>
+
+            <tr>
+                <td>tags</td>
+                <td>hindcast,model,daily</td>
+            </tr>
+
+            <tr>
+                <td>catalog_dir</td>
+                <td>https://raw.githubusercontent.com/kpegion/COLA-DATASETS-CATALOG/gh-pages/intake-catalogs/ua_RSMAS-CCSM4_climo.p.yaml</td>
+            </tr>
+    
+
+            <tr>
+                <td>last updated </td>
+                <td>2018-02-01</td>
+            </tr>
+
+
+            </tbody>
+        </table>
+    </div>
+    <div class="xarray">
+        <h3>Dataset Contents</h3>
+
+      <div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt output_prompt"></div><div><svg style="position: absolute; width: 0; height: 0; overflow: hidden">
+<defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+<path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"></path>
+<path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+<path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"></path>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+<path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"></path>
+<path d="M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+<path d="M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z"></path>
+</symbol>
+</defs>
+</svg>
+<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.
+ *
+ */
+
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.xr-wrap {
+  display: block;
+  min-width: 300px;
+  max-width: 700px;
+}
+
+.xr-text-repr-fallback {
+  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */
+  display: none;
+}
+
+.xr-header {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: solid 1px var(--xr-border-color);
+}
+
+.xr-header > div,
+.xr-header > ul {
+  display: inline;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.xr-obj-type,
+.xr-array-name {
+  margin-left: 2px;
+  margin-right: 10px;
+}
+
+.xr-obj-type {
+  color: var(--xr-font-color2);
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-array-wrap {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 20px auto;
+}
+
+.xr-array-wrap > label {
+  grid-column: 1;
+  vertical-align: top;
+}
+
+.xr-preview {
+  color: var(--xr-font-color3);
+}
+
+.xr-array-preview,
+.xr-array-data {
+  padding: 0 5px !important;
+  grid-column: 2;
+}
+
+.xr-array-data,
+.xr-array-in:checked ~ .xr-array-preview {
+  display: none;
+}
+
+.xr-array-in:checked ~ .xr-array-data,
+.xr-array-preview {
+  display: inline-block;
+}
+
+.xr-dim-list {
+  display: inline-block !important;
+  list-style: none;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.xr-dim-list li {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+}
+
+.xr-dim-list:before {
+  content: '(';
+}
+
+.xr-dim-list:after {
+  content: ')';
+}
+
+.xr-dim-list li:not(:last-child):after {
+  content: ',';
+  padding-right: 5px;
+}
+
+.xr-has-index {
+  font-weight: bold;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt, dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;
+Dimensions:  (lat: 181, lon: 360, time: 16470)
+Coordinates:
+  * lat      (lat) float32 -90.0 -89.0 -88.0 -87.0 -86.0 ... 87.0 88.0 89.0 90.0
+  * lon      (lon) float32 0.0 1.0 2.0 3.0 4.0 ... 355.0 356.0 357.0 358.0 359.0
+  * time     (time) float64 0.5 1.5 2.5 3.5 4.5 5.5 ... 40.5 41.5 42.5 43.5 44.5
+Data variables:
+    ua       (time, lat, lon) float32 dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;
+Attributes:
+    title:         SubX Climatology
+    long_title:    SubX Climatology
+    comments:      SubX project http://cola.gmu.edu/~kpegion/subx/
+    institution:   IRI
+    source:        SubX IRI
+    CreationDate:  2018/02/01 16:16:44
+    CreatedBy:     kpegion
+    MatlabSource:  </pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-22079221-6095-4d23-915c-9d35cfdfdee3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-22079221-6095-4d23-915c-9d35cfdfdee3' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 181</li><li><span class='xr-has-index'>lon</span>: 360</li><li><span class='xr-has-index'>time</span>: 16470</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-9fd1b408-8e91-4030-a147-6c09177c671c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9fd1b408-8e91-4030-a147-6c09177c671c' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-90.0 -89.0 -88.0 ... 89.0 90.0</div><input id='attrs-8d83f7e8-a9b4-4eab-80cf-237ecf4c8618' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8d83f7e8-a9b4-4eab-80cf-237ecf4c8618' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e803dd69-e58e-4885-ac44-88a8ff472ddd' class='xr-var-data-in' type='checkbox'><label for='data-e803dd69-e58e-4885-ac44-88a8ff472ddd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-90., -89., -88., -87., -86., -85., -84., -83., -82., -81., -80., -79.,
+       -78., -77., -76., -75., -74., -73., -72., -71., -70., -69., -68., -67.,
+       -66., -65., -64., -63., -62., -61., -60., -59., -58., -57., -56., -55.,
+       -54., -53., -52., -51., -50., -49., -48., -47., -46., -45., -44., -43.,
+       -42., -41., -40., -39., -38., -37., -36., -35., -34., -33., -32., -31.,
+       -30., -29., -28., -27., -26., -25., -24., -23., -22., -21., -20., -19.,
+       -18., -17., -16., -15., -14., -13., -12., -11., -10.,  -9.,  -8.,  -7.,
+        -6.,  -5.,  -4.,  -3.,  -2.,  -1.,   0.,   1.,   2.,   3.,   4.,   5.,
+         6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,
+        18.,  19.,  20.,  21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,
+        30.,  31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,  41.,
+        42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,  51.,  52.,  53.,
+        54.,  55.,  56.,  57.,  58.,  59.,  60.,  61.,  62.,  63.,  64.,  65.,
+        66.,  67.,  68.,  69.,  70.,  71.,  72.,  73.,  74.,  75.,  76.,  77.,
+        78.,  79.,  80.,  81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,
+        90.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 1.0 2.0 ... 357.0 358.0 359.0</div><input id='attrs-11b1e995-483e-4be2-b816-d9547567883d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-11b1e995-483e-4be2-b816-d9547567883d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6e7fe59e-ad5d-49f2-bf45-bb71b3c03130' class='xr-var-data-in' type='checkbox'><label for='data-6e7fe59e-ad5d-49f2-bf45-bb71b3c03130' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([  0.,   1.,   2., ..., 357., 358., 359.], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 1.5 2.5 3.5 ... 42.5 43.5 44.5</div><input id='attrs-bdb75d06-cb1a-4a60-add7-bc1965a9fa64' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bdb75d06-cb1a-4a60-add7-bc1965a9fa64' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-46d284a8-f8c9-4830-9ddc-f20662f20d53' class='xr-var-data-in' type='checkbox'><label for='data-46d284a8-f8c9-4830-9ddc-f20662f20d53' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>long_name :</span></dt><dd>Time of measurements</dd><dt><span>units :</span></dt><dd>days since 1960-01-01</dd></dl></div><div class='xr-var-data'><pre>array([ 0.5,  1.5,  2.5, ..., 42.5, 43.5, 44.5])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4c6f6ac3-10e6-415d-959f-fea973da1b84' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4c6f6ac3-10e6-415d-959f-fea973da1b84' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>ua</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(45, 181, 360), meta=np.ndarray&gt;</div><input id='attrs-9539f425-16fa-4978-9778-add32fb2698d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9539f425-16fa-4978-9778-add32fb2698d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d8c4aa1f-723d-4693-9c47-761a45920079' class='xr-var-data-in' type='checkbox'><label for='data-d8c4aa1f-723d-4693-9c47-761a45920079' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>name :</span></dt><dd>ua</dd><dt><span>long_name :</span></dt><dd>ua</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><table>
+<tr>
+<td>
+<table>
+  <thead>
+    <tr><td> </td><th> Array </th><th> Chunk </th></tr>
+  </thead>
+  <tbody>
+    <tr><th> Bytes </th><td> 4.29 GB </td> <td> 11.73 MB </td></tr>
+    <tr><th> Shape </th><td> (16470, 181, 360) </td> <td> (45, 181, 360) </td></tr>
+    <tr><th> Count </th><td> 1098 Tasks </td><td> 366 Chunks </td></tr>
+    <tr><th> Type </th><td> float32 </td><td> numpy.ndarray </td></tr>
+  </tbody>
+</table>
+</td>
+<td>
+<svg width="160" height="146" style="stroke:rgb(0,0,0);stroke-width:1" >
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="10" y1="25" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="10" y2="25" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="10" y1="0" x2="10" y2="26" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="11" y1="1" x2="11" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="27" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="12" y1="2" x2="12" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="28" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="13" y1="3" x2="13" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="29" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="14" y1="4" x2="14" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="30" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="15" y1="5" x2="15" y2="31" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="16" y1="6" x2="16" y2="32" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="17" y1="7" x2="17" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="33" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="18" y1="8" x2="18" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="34" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="19" y1="9" x2="19" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="35" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="20" y1="10" x2="20" y2="36" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="21" y1="11" x2="21" y2="37" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="22" y1="12" x2="22" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="38" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="23" y1="13" x2="23" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="39" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="24" y1="14" x2="24" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="40" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="25" y1="15" x2="25" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="41" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="26" y1="16" x2="26" y2="42" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="27" y1="17" x2="27" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="43" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="28" y1="18" x2="28" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="44" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="29" y1="19" x2="29" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="45" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="30" y1="20" x2="30" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="46" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="31" y1="21" x2="31" y2="47" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="32" y1="22" x2="32" y2="48" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="33" y1="23" x2="33" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="49" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="34" y1="24" x2="34" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="50" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="35" y1="25" x2="35" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="51" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="36" y1="26" x2="36" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="52" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="37" y1="27" x2="37" y2="53" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="38" y1="28" x2="38" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="54" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="39" y1="29" x2="39" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="55" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="40" y1="30" x2="40" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="56" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="41" y1="31" x2="41" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="57" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="42" y1="32" x2="42" y2="58" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="43" y1="33" x2="43" y2="59" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="44" y1="34" x2="44" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="60" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="45" y1="35" x2="45" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="61" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="46" y1="36" x2="46" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="62" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="47" y1="37" x2="47" y2="63" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="48" y1="38" x2="48" y2="64" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="49" y1="39" x2="49" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="65" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="50" y1="40" x2="50" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="66" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="51" y1="41" x2="51" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="67" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="52" y1="42" x2="52" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="68" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="53" y1="43" x2="53" y2="69" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="54" y1="44" x2="54" y2="70" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="55" y1="45" x2="55" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="71" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="56" y1="46" x2="56" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="72" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="57" y1="47" x2="57" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="73" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="58" y1="48" x2="58" y2="74" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="59" y1="49" x2="59" y2="75" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="60" y1="50" x2="60" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="76" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="61" y1="51" x2="61" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="77" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="62" y1="52" x2="62" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="78" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="63" y1="53" x2="63" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="79" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="64" y1="54" x2="64" y2="80" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="65" y1="55" x2="65" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="81" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="66" y1="56" x2="66" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="82" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="67" y1="57" x2="67" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="83" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="68" y1="58" x2="68" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="84" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="69" y1="59" x2="69" y2="85" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="70" y1="60" x2="70" y2="86" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="71" y1="61" x2="71" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="87" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="72" y1="62" x2="72" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="88" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="73" y1="63" x2="73" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="89" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="74" y1="64" x2="74" y2="90" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="75" y1="65" x2="75" y2="91" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="76" y1="66" x2="76" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="92" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="77" y1="67" x2="77" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="93" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="78" y1="68" x2="78" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="94" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="79" y1="69" x2="79" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="95" />
+  <line x1="80" y1="70" x2="80" y2="96" />
+  <line x1="80" y1="70" x2="80" y2="96" />
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 80.588235,70.588235 80.588235,96.458380 10.000000,25.870145" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="10" y1="0" x2="39" y2="0" style="stroke-width:2" />
+  <line x1="10" y1="0" x2="39" y2="0" />
+  <line x1="10" y1="0" x2="39" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="10" y1="0" x2="40" y2="0" />
+  <line x1="11" y1="1" x2="40" y2="1" />
+  <line x1="11" y1="1" x2="40" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="11" y1="1" x2="41" y2="1" />
+  <line x1="12" y1="2" x2="41" y2="2" />
+  <line x1="12" y1="2" x2="41" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="12" y1="2" x2="42" y2="2" />
+  <line x1="13" y1="3" x2="42" y2="3" />
+  <line x1="13" y1="3" x2="42" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="13" y1="3" x2="43" y2="3" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="43" y2="4" />
+  <line x1="14" y1="4" x2="44" y2="4" />
+  <line x1="14" y1="4" x2="44" y2="4" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="44" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="15" y1="5" x2="45" y2="5" />
+  <line x1="16" y1="6" x2="45" y2="6" />
+  <line x1="16" y1="6" x2="45" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="16" y1="6" x2="46" y2="6" />
+  <line x1="17" y1="7" x2="46" y2="7" />
+  <line x1="17" y1="7" x2="46" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="17" y1="7" x2="47" y2="7" />
+  <line x1="18" y1="8" x2="47" y2="8" />
+  <line x1="18" y1="8" x2="47" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="18" y1="8" x2="48" y2="8" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="48" y2="9" />
+  <line x1="19" y1="9" x2="49" y2="9" />
+  <line x1="19" y1="9" x2="49" y2="9" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="49" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="20" y1="10" x2="50" y2="10" />
+  <line x1="21" y1="11" x2="50" y2="11" />
+  <line x1="21" y1="11" x2="50" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="21" y1="11" x2="51" y2="11" />
+  <line x1="22" y1="12" x2="51" y2="12" />
+  <line x1="22" y1="12" x2="51" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="22" y1="12" x2="52" y2="12" />
+  <line x1="23" y1="13" x2="52" y2="13" />
+  <line x1="23" y1="13" x2="52" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="23" y1="13" x2="53" y2="13" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="53" y2="14" />
+  <line x1="24" y1="14" x2="54" y2="14" />
+  <line x1="24" y1="14" x2="54" y2="14" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="54" y2="15" />
+  <line x1="25" y1="15" x2="55" y2="15" />
+  <line x1="25" y1="15" x2="55" y2="15" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="55" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="26" y1="16" x2="56" y2="16" />
+  <line x1="27" y1="17" x2="56" y2="17" />
+  <line x1="27" y1="17" x2="56" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="27" y1="17" x2="57" y2="17" />
+  <line x1="28" y1="18" x2="57" y2="18" />
+  <line x1="28" y1="18" x2="57" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="28" y1="18" x2="58" y2="18" />
+  <line x1="29" y1="19" x2="58" y2="19" />
+  <line x1="29" y1="19" x2="58" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="29" y1="19" x2="59" y2="19" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="59" y2="20" />
+  <line x1="30" y1="20" x2="60" y2="20" />
+  <line x1="30" y1="20" x2="60" y2="20" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="60" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="31" y1="21" x2="61" y2="21" />
+  <line x1="32" y1="22" x2="61" y2="22" />
+  <line x1="32" y1="22" x2="61" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="32" y1="22" x2="62" y2="22" />
+  <line x1="33" y1="23" x2="62" y2="23" />
+  <line x1="33" y1="23" x2="62" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="33" y1="23" x2="63" y2="23" />
+  <line x1="34" y1="24" x2="63" y2="24" />
+  <line x1="34" y1="24" x2="63" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="34" y1="24" x2="64" y2="24" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="64" y2="25" />
+  <line x1="35" y1="25" x2="65" y2="25" />
+  <line x1="35" y1="25" x2="65" y2="25" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="65" y2="26" />
+  <line x1="36" y1="26" x2="66" y2="26" />
+  <line x1="36" y1="26" x2="66" y2="26" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="66" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="37" y1="27" x2="67" y2="27" />
+  <line x1="38" y1="28" x2="67" y2="28" />
+  <line x1="38" y1="28" x2="67" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="38" y1="28" x2="68" y2="28" />
+  <line x1="39" y1="29" x2="68" y2="29" />
+  <line x1="39" y1="29" x2="68" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="39" y1="29" x2="69" y2="29" />
+  <line x1="40" y1="30" x2="69" y2="30" />
+  <line x1="40" y1="30" x2="69" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="40" y1="30" x2="70" y2="30" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="70" y2="31" />
+  <line x1="41" y1="31" x2="71" y2="31" />
+  <line x1="41" y1="31" x2="71" y2="31" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="71" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="42" y1="32" x2="72" y2="32" />
+  <line x1="43" y1="33" x2="72" y2="33" />
+  <line x1="43" y1="33" x2="72" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="43" y1="33" x2="73" y2="33" />
+  <line x1="44" y1="34" x2="73" y2="34" />
+  <line x1="44" y1="34" x2="73" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="44" y1="34" x2="74" y2="34" />
+  <line x1="45" y1="35" x2="74" y2="35" />
+  <line x1="45" y1="35" x2="74" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="45" y1="35" x2="75" y2="35" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="75" y2="36" />
+  <line x1="46" y1="36" x2="76" y2="36" />
+  <line x1="46" y1="36" x2="76" y2="36" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="76" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="47" y1="37" x2="77" y2="37" />
+  <line x1="48" y1="38" x2="77" y2="38" />
+  <line x1="48" y1="38" x2="77" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="48" y1="38" x2="78" y2="38" />
+  <line x1="49" y1="39" x2="78" y2="39" />
+  <line x1="49" y1="39" x2="78" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="49" y1="39" x2="79" y2="39" />
+  <line x1="50" y1="40" x2="79" y2="40" />
+  <line x1="50" y1="40" x2="79" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="50" y1="40" x2="80" y2="40" />
+  <line x1="51" y1="41" x2="80" y2="41" />
+  <line x1="51" y1="41" x2="80" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="51" y1="41" x2="81" y2="41" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="81" y2="42" />
+  <line x1="52" y1="42" x2="82" y2="42" />
+  <line x1="52" y1="42" x2="82" y2="42" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="82" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="53" y1="43" x2="83" y2="43" />
+  <line x1="54" y1="44" x2="83" y2="44" />
+  <line x1="54" y1="44" x2="83" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="54" y1="44" x2="84" y2="44" />
+  <line x1="55" y1="45" x2="84" y2="45" />
+  <line x1="55" y1="45" x2="84" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="55" y1="45" x2="85" y2="45" />
+  <line x1="56" y1="46" x2="85" y2="46" />
+  <line x1="56" y1="46" x2="85" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="56" y1="46" x2="86" y2="46" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="86" y2="47" />
+  <line x1="57" y1="47" x2="87" y2="47" />
+  <line x1="57" y1="47" x2="87" y2="47" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="87" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="58" y1="48" x2="88" y2="48" />
+  <line x1="59" y1="49" x2="88" y2="49" />
+  <line x1="59" y1="49" x2="88" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="59" y1="49" x2="89" y2="49" />
+  <line x1="60" y1="50" x2="89" y2="50" />
+  <line x1="60" y1="50" x2="89" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="60" y1="50" x2="90" y2="50" />
+  <line x1="61" y1="51" x2="90" y2="51" />
+  <line x1="61" y1="51" x2="90" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="61" y1="51" x2="91" y2="51" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="91" y2="52" />
+  <line x1="62" y1="52" x2="92" y2="52" />
+  <line x1="62" y1="52" x2="92" y2="52" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="92" y2="53" />
+  <line x1="63" y1="53" x2="93" y2="53" />
+  <line x1="63" y1="53" x2="93" y2="53" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="93" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="64" y1="54" x2="94" y2="54" />
+  <line x1="65" y1="55" x2="94" y2="55" />
+  <line x1="65" y1="55" x2="94" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="65" y1="55" x2="95" y2="55" />
+  <line x1="66" y1="56" x2="95" y2="56" />
+  <line x1="66" y1="56" x2="95" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="66" y1="56" x2="96" y2="56" />
+  <line x1="67" y1="57" x2="96" y2="57" />
+  <line x1="67" y1="57" x2="96" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="67" y1="57" x2="97" y2="57" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="97" y2="58" />
+  <line x1="68" y1="58" x2="98" y2="58" />
+  <line x1="68" y1="58" x2="98" y2="58" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="98" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="69" y1="59" x2="99" y2="59" />
+  <line x1="70" y1="60" x2="99" y2="60" />
+  <line x1="70" y1="60" x2="99" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="70" y1="60" x2="100" y2="60" />
+  <line x1="71" y1="61" x2="100" y2="61" />
+  <line x1="71" y1="61" x2="100" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="71" y1="61" x2="101" y2="61" />
+  <line x1="72" y1="62" x2="101" y2="62" />
+  <line x1="72" y1="62" x2="101" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="72" y1="62" x2="102" y2="62" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="102" y2="63" />
+  <line x1="73" y1="63" x2="103" y2="63" />
+  <line x1="73" y1="63" x2="103" y2="63" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="103" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="74" y1="64" x2="104" y2="64" />
+  <line x1="75" y1="65" x2="104" y2="65" />
+  <line x1="75" y1="65" x2="104" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="75" y1="65" x2="105" y2="65" />
+  <line x1="76" y1="66" x2="105" y2="66" />
+  <line x1="76" y1="66" x2="105" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="76" y1="66" x2="106" y2="66" />
+  <line x1="77" y1="67" x2="106" y2="67" />
+  <line x1="77" y1="67" x2="106" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="77" y1="67" x2="107" y2="67" />
+  <line x1="78" y1="68" x2="107" y2="68" />
+  <line x1="78" y1="68" x2="107" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="78" y1="68" x2="108" y2="68" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="108" y2="69" />
+  <line x1="79" y1="69" x2="109" y2="69" />
+  <line x1="79" y1="69" x2="109" y2="69" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="109" y2="70" />
+  <line x1="80" y1="70" x2="110" y2="70" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="10" y1="0" x2="80" y2="70" style="stroke-width:2" />
+  <line x1="39" y1="0" x2="110" y2="70" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="10.000000,0.000000 39.534638,0.000000 110.122874,70.588235 80.588235,70.588235" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Horizontal lines -->
+  <line x1="80" y1="70" x2="110" y2="70" style="stroke-width:2" />
+  <line x1="80" y1="96" x2="110" y2="96" style="stroke-width:2" />
+
+  <!-- Vertical lines -->
+  <line x1="80" y1="70" x2="80" y2="96" style="stroke-width:2" />
+  <line x1="110" y1="70" x2="110" y2="96" style="stroke-width:2" />
+
+  <!-- Colored Rectangle -->
+  <polygon points="80.588235,70.588235 110.122874,70.588235 110.122874,96.458380 80.588235,96.458380" style="fill:#ECB172A0;stroke-width:0"/>
+
+  <!-- Text -->
+  <text x="95.355554" y="116.458380" font-size="1.0rem" font-weight="100" text-anchor="middle" >360</text>
+  <text x="130.122874" y="83.523308" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(-90,130.122874,83.523308)">181</text>
+  <text x="35.294118" y="81.164263" font-size="1.0rem" font-weight="100" text-anchor="middle" transform="rotate(45,35.294118,81.164263)">16470</text>
+</svg>
+</td>
+</tr>
+</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-3b6a1f8b-9642-45ce-9098-d430ce9e9eb6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-3b6a1f8b-9642-45ce-9098-d430ce9e9eb6' class='xr-section-summary' >Attributes: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>SubX Climatology</dd><dt><span>long_title :</span></dt><dd>SubX Climatology</dd><dt><span>comments :</span></dt><dd>SubX project http://cola.gmu.edu/~kpegion/subx/</dd><dt><span>institution :</span></dt><dd>IRI</dd><dt><span>source :</span></dt><dd>SubX IRI</dd><dt><span>CreationDate :</span></dt><dd>2018/02/01 16:16:44</dd><dt><span>CreatedBy :</span></dt><dd>kpegion</dd><dt><span>MatlabSource :</span></dt><dd></dd></dl></div></li></ul></div></div>
+    
+
+
+    </div>
+  </div>
+
+</main>
+
+
+    
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION


These 9 hindcast ua200 climo datasets cataloged:
ECCC-GEM, ECCC-GEPS, ECCC-GEPS5, ECCC-GEPS6, EMC-GEFS,  ESRL-FIMr1p1,  GMAO-GEOS_V2p1,   NRL-NESM  and RSMAS-CCSM4

Also, these 6 hindcast ua200 anoms datasets were cataloged:
ECCC-GEM, EMC-GEFS,  ESRL-FIMr1p1,  GMAO-GEOS_V2p1,  NRL-NESM  and RSMAS-CCSM4
